### PR TITLE
fix: 修复文件下载内容为 undefined

### DIFF
--- a/front/src/layout/file-manager/explorer.vue
+++ b/front/src/layout/file-manager/explorer.vue
@@ -30,7 +30,7 @@ const files = ref([])
 
 const download = async (file) => {
   const response = await api.download(file.path)
-  downloadFile(file.name, response.data)
+  downloadFile(file.name, response)
 }
 
 actions.loadFiles = async (path = state.currentPath) => {


### PR DESCRIPTION
在下载文件时，由于 Axios 响应拦截器已经处理了解包逻辑（直接返回了 data），在 `explorer.vue` 的 `download` 方法中再次访问 `.data` 属性会导致获取到的内容为 `undefined`