### PR TITLE
refactor(swarm): 优化服务端口结构和过滤逻辑

### DIFF
--- a/pkgs/swarm/service.go
+++ b/pkgs/swarm/service.go
@@ -63,15 +63,17 @@ func (m *SwarmManager) ListServices(ctx context.Context) ([]SwarmService, error)
 			svc.Replicas = s.Spec.Mode.Replicated.Replicas
 		}
 
-		var ports []interface{}
+		var ports []SwarmServicePort
 		for _, p := range s.Endpoint.Ports {
-			if p.PublishedPort > 0 {
-				ports = append(ports, map[string]interface{}{
-					"published": p.PublishedPort,
-					"target":    p.TargetPort,
-					"protocol":  string(p.Protocol),
-				})
+			if p.PublishedPort == 0 && p.TargetPort == 0 {
+				continue
 			}
+			ports = append(ports, SwarmServicePort{
+				Protocol:      string(p.Protocol),
+				TargetPort:    p.TargetPort,
+				PublishedPort: p.PublishedPort,
+				PublishMode:   string(p.PublishMode),
+			})
 		}
 		svc.Ports = ports
 


### PR DESCRIPTION
- 将端口数据类型从 interface{} 数组改为 SwarmServicePort 结构体
- 添加对发布端口和目标端口都为 0 的情况的过滤处理
- 重构端口信息映射逻辑，使用结构体字段直接赋值
- 添加 PublishMode 字段到端口信息中
- 移除旧的 map[string]interface{} 映射方式