### PR TITLE
feat: 添加终端按钮权限控制，确保只有具备写权限的用户可访问

### DIFF
--- a/webview/src/router/index.ts
+++ b/webview/src/router/index.ts
@@ -191,6 +191,12 @@ router.beforeEach((to) => {
     return permState.allowTerminal ? true : { path: '/overview' }
   }
 
+  // 容器终端需要 docker 写权限
+  if (to.name === 'docker-container-terminal') {
+    const perm = permState.permissions['docker'] || ''
+    return perm === 'rw' ? true : { path: '/overview' }
+  }
+
   for (const [prefix, module] of routePermMap) {
     if (to.path.startsWith(prefix)) {
       const perm = permState.permissions[module] || ''

--- a/webview/src/views/docker/containers.vue
+++ b/webview/src/views/docker/containers.vue
@@ -279,7 +279,7 @@ export default toNative(Containers)
                     <button v-if="ct.state === 'running'" @click="$router.push({ path: '/docker/container/' + ct.id + '/logs' })" class="btn-icon text-slate-600 hover:bg-slate-50" title="日志">
                       <i class="fas fa-file-lines text-xs"></i>
                     </button>
-                    <button v-if="ct.state === 'running'" @click="$router.push({ path: '/docker/container/' + ct.id + '/terminal' })" class="btn-icon text-teal-600 hover:bg-teal-50" title="登录终端">
+                    <button v-if="ct.state === 'running' && actions.hasPerm('docker', true)" @click="$router.push({ path: '/docker/container/' + ct.id + '/terminal' })" class="btn-icon text-teal-600 hover:bg-teal-50" title="登录终端">
                       <i class="fas fa-terminal text-xs"></i>
                     </button>
                     <button v-if="ct.state !== 'running' && actions.hasPerm('docker', true)" @click="handleContainerAction(ct, 'start')" class="btn-icon text-emerald-600 hover:bg-emerald-50" title="启动">
@@ -352,7 +352,7 @@ export default toNative(Containers)
               <button v-if="ct.state === 'running'" @click="$router.push({ path: '/docker/container/' + ct.id + '/stats' })" class="btn-icon text-indigo-600 hover:bg-indigo-50" title="统计">
                 <i class="fas fa-chart-bar text-xs"></i><span class="text-xs ml-1">统计</span>
               </button>
-              <button v-if="ct.state === 'running'" @click="$router.push({ path: '/docker/container/' + ct.id + '/terminal' })" class="btn-icon text-teal-600 hover:bg-teal-50" title="终端">
+              <button v-if="ct.state === 'running' && actions.hasPerm('docker', true)" @click="$router.push({ path: '/docker/container/' + ct.id + '/terminal' })" class="btn-icon text-teal-600 hover:bg-teal-50" title="终端">
                 <i class="fas fa-terminal text-xs"></i><span class="text-xs ml-1">终端</span>
               </button>
               <button v-if="ct.state !== 'running' && actions.hasPerm('docker', true)" @click="handleContainerAction(ct, 'start')" class="btn-icon text-emerald-600 hover:bg-emerald-50" title="启动">

--- a/webview/src/views/docker/widget/container-nav.vue
+++ b/webview/src/views/docker/widget/container-nav.vue
@@ -82,7 +82,7 @@ export default toNative(ContainerNav)
           <button @click="switchTab('docker-container-logs')" :class="['px-3 py-1 text-xs font-medium rounded-md transition-all duration-200 flex items-center gap-1.5', activeTab === 'docker-container-logs' ? 'bg-white text-emerald-600 shadow-sm' : 'text-slate-500 hover:text-slate-700']">
             <i class="fas fa-file-lines"></i><span>日志</span>
           </button>
-          <button @click="switchTab('docker-container-terminal')" :class="['px-3 py-1 text-xs font-medium rounded-md transition-all duration-200 flex items-center gap-1.5', activeTab === 'docker-container-terminal' ? 'bg-white text-emerald-600 shadow-sm' : 'text-slate-500 hover:text-slate-700']">
+          <button v-if="actions.hasPerm('docker', true)" @click="switchTab('docker-container-terminal')" :class="['px-3 py-1 text-xs font-medium rounded-md transition-all duration-200 flex items-center gap-1.5', activeTab === 'docker-container-terminal' ? 'bg-white text-emerald-600 shadow-sm' : 'text-slate-500 hover:text-slate-700']">
             <i class="fas fa-terminal"></i><span>终端</span>
           </button>
         </div>
@@ -118,7 +118,7 @@ export default toNative(ContainerNav)
         <button @click="switchTab('docker-container-logs')" :class="['px-3 py-1 text-xs font-medium rounded-md transition-all duration-200 flex items-center gap-1.5', activeTab === 'docker-container-logs' ? 'bg-white text-emerald-600 shadow-sm' : 'text-slate-500 hover:text-slate-700']">
           <i class="fas fa-file-lines"></i><span class="hidden sm:inline">日志</span>
         </button>
-        <button @click="switchTab('docker-container-terminal')" :class="['px-3 py-1 text-xs font-medium rounded-md transition-all duration-200 flex items-center gap-1.5', activeTab === 'docker-container-terminal' ? 'bg-white text-emerald-600 shadow-sm' : 'text-slate-500 hover:text-slate-700']">
+        <button v-if="actions.hasPerm('docker', true)" @click="switchTab('docker-container-terminal')" :class="['px-3 py-1 text-xs font-medium rounded-md transition-all duration-200 flex items-center gap-1.5', activeTab === 'docker-container-terminal' ? 'bg-white text-emerald-600 shadow-sm' : 'text-slate-500 hover:text-slate-700']">
           <i class="fas fa-terminal"></i><span class="hidden sm:inline">终端</span>
         </button>
       </div>


### PR DESCRIPTION
Summarize Create By Copilot:

This pull request strengthens permission checks for accessing Docker container terminals in the UI. Now, users must have Docker write permissions to see or access terminal-related buttons and routes. The main changes are as follows:

**Permission enforcement for Docker terminal:**

* Added a route guard in `webview/src/router/index.ts` to restrict navigation to the Docker container terminal page (`docker-container-terminal`) to users with Docker write (`rw`) permissions.

**UI updates for Docker container terminal access:**

* Updated `webview/src/views/docker/containers.vue` to only show the "登录终端" and "终端" buttons if the container is running and the user has Docker write permission. [[1]](diffhunk://#diff-98429782c0fa3e188aa96c2b3d2b0949dcb348f345295bc10dafe4cfe95d4651L282-R282) [[2]](diffhunk://#diff-98429782c0fa3e188aa96c2b3d2b0949dcb348f345295bc10dafe4cfe95d4651L355-R355)
* Updated `webview/src/views/docker/widget/container-nav.vue` to only render the terminal tab button if the user has Docker write permission. [[1]](diffhunk://#diff-32b0e2d3c32e8fc2b9e1dff529e2fa96aa1463a50adeea74002844f0b05d0abfL85-R85) [[2]](diffhunk://#diff-32b0e2d3c32e8fc2b9e1dff529e2fa96aa1463a50adeea74002844f0b05d0abfL121-R121)