### PR TITLE
fix(system): 解决无token时系统概览页面网络轮询问题

### DIFF
--- a/webview/src/views/system/overview.vue
+++ b/webview/src/views/system/overview.vue
@@ -421,6 +421,7 @@ class SystemOverview extends Vue {
     }
 
     async pollNet() {
+        if (!localStorage.getItem('app-token')) { this.stopPoll(); return }
         try {
             const res = await api.systemStat()
             const payload = res.payload as SystemStat | undefined


### PR DESCRIPTION
- 添加了对本地存储中app-token的检查
- 在缺少token时停止轮询并返回
- 防止无认证情况下发起无效的系统状态请求

---

Summarize Create By Copilot:

This pull request introduces a small but important improvement to the polling logic in the `system/overview.vue` component. The change ensures that network polling is stopped if the `app-token` is not present in `localStorage`, preventing unnecessary API calls when the user is not authenticated.

- Improved polling logic:
  * [`webview/src/views/system/overview.vue`](diffhunk://#diff-b01adb0f4e20fc0cb8ca7a00f1e3f16c51297a16a00638c484aa725327b9706fR424): Added a check in the `pollNet` method to stop polling if `app-token` is missing from `localStorage`.