### PR TITLE
refactor(system): 移除 NVIDIA NVML 依赖并优化 GPU 统计收集

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module isrvd
 go 1.25.0
 
 require (
-	github.com/NVIDIA/go-nvml v0.13.0-1
 	github.com/compose-spec/compose-go/v2 v2.10.2
 	github.com/creack/pty v1.1.24
 	github.com/docker/docker v28.5.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEK
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/NVIDIA/go-nvml v0.13.0-1 h1:OLX8Jq3dONuPOQPC7rndB6+iDmDakw0XTYgzMxObkEw=
-github.com/NVIDIA/go-nvml v0.13.0-1/go.mod h1:+KNA7c7gIBH7SKSJ1ntlwkfN80zdx8ovl4hrK3LmPt4=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/bytedance/gopkg v0.1.4 h1:oZnQwnX82KAIWb7033bEwtxvTqXcYMxDBaQxo5JJHWM=

--- a/internal/service/system/gpu.go
+++ b/internal/service/system/gpu.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/jaypipes/ghw"
 	ghwgpu "github.com/jaypipes/ghw/pkg/gpu"
 )
@@ -127,76 +126,7 @@ func collectNvidiaCards(cards []*ghwgpu.GraphicsCard) []*GPUStat {
 	if len(cards) == 0 {
 		return nil
 	}
-	if stats := collectNvidiaNVML(); len(stats) > 0 {
-		return stats
-	}
 	return collectNvidiaSmi(cards)
-}
-
-// go-nvml 直接读取 NVIDIA 驱动
-func collectNvidiaNVML() []*GPUStat {
-	ret := nvml.Init()
-	if ret != nvml.SUCCESS {
-		return nil
-	}
-	defer nvml.Shutdown()
-
-	count, ret := nvml.DeviceGetCount()
-	if ret != nvml.SUCCESS || count == 0 {
-		return nil
-	}
-
-	stats := make([]*GPUStat, 0, count)
-	for i := 0; i < count; i++ {
-		device, ret := nvml.DeviceGetHandleByIndex(i)
-		if ret != nvml.SUCCESS {
-			continue
-		}
-
-		name := "NVIDIA GPU"
-		if n, r := device.GetName(); r == nvml.SUCCESS {
-			name = n
-		}
-
-		var memUsed, memTotal uint64
-		if mem, r := device.GetMemoryInfo(); r == nvml.SUCCESS {
-			memUsed = mem.Used
-			memTotal = mem.Total
-		}
-
-		var util float64
-		if u, r := device.GetUtilizationRates(); r == nvml.SUCCESS {
-			util = float64(u.Gpu)
-		}
-
-		temp := -1
-		if t, r := device.GetTemperature(nvml.TEMPERATURE_GPU); r == nvml.SUCCESS {
-			temp = int(t)
-		}
-
-		powerW := -1.0
-		if p, r := device.GetPowerUsage(); r == nvml.SUCCESS {
-			powerW = float64(p) / 1000 // mW → W
-		}
-
-		fan := -1
-		if f, r := device.GetFanSpeed(); r == nvml.SUCCESS {
-			fan = int(f)
-		}
-
-		stats = append(stats, &GPUStat{
-			Index:       i,
-			Name:        name,
-			Vendor:      "nvidia",
-			MemoryUsed:  memUsed,
-			MemoryTotal: memTotal,
-			Utilization: util,
-			Temperature: temp,
-			PowerUsage:  powerW,
-			FanSpeed:    fan,
-		})
-	}
-	return stats
 }
 
 // nvidia-smi fallback


### PR DESCRIPTION
- 移除了 github.com/NVIDIA/go-nvml 依赖包
- 删除了基于 NVML 的 GPU 统计收集函数 collectNvidiaNVML
- 简化了 GPU 统计收集逻辑，仅保留 nvidia-smi 回退方案
- 更新了 go.mod 和 go.sum 文件以反映依赖变更