### PR TITLE
feat: 镜像列表支持拉取更新，修复私有仓库镜像引用重复拼接

### DIFF
--- a/webview/src/views/docker/images.vue
+++ b/webview/src/views/docker/images.vue
@@ -69,6 +69,37 @@ class Images extends Vue {
         return { host: '', name: tag }
     }
 
+    async pullImage(image: DockerImageInfo) {
+        const tag = image.repoTags.find(t => t !== '<none>:<none>')
+        if (!tag || tag === '<none>:<none>') {
+            this.actions.showNotification('error', '该镜像没有有效的 Tag，无法拉取')
+            return
+        }
+        // 根据镜像 tag 的 host 自动匹配已配置的 registry，以便携带认证信息
+        const { host: tagHost, name: imageName } = this.parseImageRef(tag)
+        const matchedRegistry = tagHost
+            ? this.registries.find(r => r.url === tagHost || r.url.replace(/^https?:\/\//, '') === tagHost)
+            : null
+        const registryUrl = matchedRegistry ? matchedRegistry.url : ''
+        this.actions.showConfirm({
+            title: '拉取镜像',
+            message: `确定要重新拉取镜像 <strong class="text-slate-900">${tag}</strong> 吗？`,
+            icon: 'fa-download',
+            iconColor: 'blue',
+            confirmText: '确认拉取',
+            danger: false,
+            onConfirm: async () => {
+                try {
+                    await api.pullFromRegistry(imageName, registryUrl, '')
+                    this.actions.showNotification('success', '镜像拉取成功')
+                    this.loadImages()
+                } catch (e: any) {
+                    this.actions.showNotification('error', e.message || '镜像拉取失败')
+                }
+            }
+        })
+    }
+
     handleImageAction(image: DockerImageInfo, action: string) {
         this.actions.showConfirm({
             title: '删除镜像',
@@ -216,7 +247,10 @@ export default toNative(Images)
                   <button @click="tagModalRef?.show(img)" v-if="actions.hasPerm('docker', true)" class="btn-icon text-blue-600 hover:bg-blue-50" title="打标签">
                     <i class="fas fa-tag text-xs"></i>
                   </button>
-                  <button @click="openPush(img)" v-if="actions.hasPerm('docker', true)" :disabled="registries.length === 0" class="btn-icon text-blue-600 hover:bg-blue-50 disabled:opacity-40 disabled:cursor-not-allowed" :title="registries.length === 0 ? '暂无可用私有仓库' : '推送到仓库'">
+                  <button @click="pullImage(img)" v-if="actions.hasPerm('docker', true)" class="btn-icon text-emerald-600 hover:bg-emerald-50" title="拉取（更新）">
+                    <i class="fas fa-download text-xs"></i>
+                  </button>
+                  <button @click="openPush(img)" v-if="actions.hasPerm('docker', true)" :disabled="registries.length === 0" class="btn-icon text-indigo-600 hover:bg-indigo-50 disabled:opacity-40 disabled:cursor-not-allowed" :title="registries.length === 0 ? '暂无可用私有仓库' : '推送到仓库'">
                     <i class="fas fa-upload text-xs"></i>
                   </button>
                   <button @click="handleImageAction(img, 'remove')" v-if="actions.hasPerm('docker', true)" class="btn-icon text-red-600 hover:bg-red-50" title="删除">
@@ -269,7 +303,10 @@ export default toNative(Images)
             <button @click="tagModalRef?.show(img)" v-if="actions.hasPerm('docker', true)" class="btn-icon text-blue-600 hover:bg-blue-50" title="打标签">
               <i class="fas fa-tag text-xs"></i><span class="text-xs ml-1">标签</span>
             </button>
-            <button @click="openPush(img)" v-if="actions.hasPerm('docker', true)" :disabled="registries.length === 0" class="btn-icon text-blue-600 hover:bg-blue-50 disabled:opacity-40 disabled:cursor-not-allowed" :title="registries.length === 0 ? '暂无可用私有仓库' : '推送到仓库'">
+            <button @click="pullImage(img)" v-if="actions.hasPerm('docker', true)" class="btn-icon text-emerald-600 hover:bg-emerald-50" title="拉取（更新）">
+              <i class="fas fa-download text-xs"></i><span class="text-xs ml-1">拉取</span>
+            </button>
+            <button @click="openPush(img)" v-if="actions.hasPerm('docker', true)" :disabled="registries.length === 0" class="btn-icon text-indigo-600 hover:bg-indigo-50 disabled:opacity-40 disabled:cursor-not-allowed" :title="registries.length === 0 ? '暂无可用私有仓库' : '推送到仓库'">
               <i class="fas fa-upload text-xs"></i><span class="text-xs ml-1">推送</span>
             </button>
             <button @click="handleImageAction(img, 'remove')" v-if="actions.hasPerm('docker', true)" class="btn-icon text-red-600 hover:bg-red-50" title="删除">


### PR DESCRIPTION
- 镜像列表新增"拉取（更新）"按钮，自动根据镜像 tag 的 host 匹配已配置的私有仓库以携带认证信息去拉取镜像
- 后端 `PullFromRegistry` 修复当 image 已包含 registry host 前缀时重复拼接的问题，同时将 tag/digest 检查对象从 `req.Image` 修正为最终的 `imageRef