### PR TITLE
fix: 移除冗余预初始化，改为运行按需创建

### DIFF
--- a/build/docker-slim/entrypoint.sh
+++ b/build/docker-slim/entrypoint.sh
@@ -13,7 +13,7 @@ CONF_DIR="/data/conf"
 DEFAULTS_DIR="/etc/defaults"
 
 mkdir -p "$CONF_DIR"
-mkdir -p /data/conf /data/container
+mkdir -p /data/conf
 
 # 遍历默认配置模板，不存在则自动拷贝
 for file in "$DEFAULTS_DIR"/*; do

--- a/build/docker/entrypoint.sh
+++ b/build/docker/entrypoint.sh
@@ -14,7 +14,7 @@ DEFAULTS_DIR="/etc/defaults"
 
 mkdir -p "$CONF_DIR"
 mkdir -p /var/log/supervisor
-mkdir -p /data/conf /data/etcd /data/container
+mkdir -p /data/conf /data/etcd
 
 # 遍历默认配置模板，不存在则自动拷贝
 for file in "$DEFAULTS_DIR"/*; do

--- a/pkgs/docker/container.go
+++ b/pkgs/docker/container.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -232,6 +233,9 @@ func (s *DockerService) CreateContainer(ctx context.Context, req ContainerCreate
 			hostPath := vol.HostPath
 			if s.config.ContainerRoot != "" && !filepath.IsAbs(hostPath) {
 				hostPath = filepath.Join(s.config.ContainerRoot, req.Name, hostPath)
+				if err := os.MkdirAll(hostPath, 0755); err != nil {
+					return "", fmt.Errorf("创建卷目录失败: %w", err)
+				}
 			}
 			bind := hostPath + ":" + vol.ContainerPath
 			if vol.ReadOnly {


### PR DESCRIPTION
**Motivation**
entrypoint 中无条件预创建 /data/container 目录，与配置文件声明的 containerRoot 行为不一致——配置可能指向其他路径，或未使用该目录。改为所有实际使用路径都自己 MkdirAll

**Changes**
 - pkgs/docker/container.go：CreateContainer 拼接相对卷路径后调用 os.MkdirAll 确保目录存在
 - build/docker/entrypoint.sh、build/docker-slim/entrypoint.sh：移除 /data/container 的 mkdir