### PR TITLE
fix: 修复下载功能

### DIFF
--- a/webview/src/service/axios.ts
+++ b/webview/src/service/axios.ts
@@ -42,6 +42,21 @@ export const interceptors = (state: { token: string | null; loading: boolean }, 
         }
     )
 
+    axiosBlobInstance.interceptors.request.use(
+        (config: InternalAxiosRequestConfig) => {
+            if (state.token) {
+                config.headers['Authorization'] = state.token
+            }
+            return config
+        },
+        (error: unknown) => Promise.reject(error)
+    )
+
+    axiosBlobInstance.interceptors.response.use(
+        (value: AxiosResponse) => value.data,
+        (error: unknown) => Promise.reject(error)
+    )
+
     axiosInstance.interceptors.response.use(
         (value: AxiosResponse) => {
             // 过滤逻辑：不显示 GET 请求和 HTTP 200 状态码的消息


### PR DESCRIPTION
**Motivation**

- 普通接口请求会通过 `axiosInstance` 自动注入 token，但 Blob 下载请求使用独立的 `axiosBlobInstance`，未统一鉴权逻辑，导致需要登录态的下载接口可能请求失败
- Blob 下载响应未统一解包，调用方期望拿到 `Blob`，但实际拿到 `AxiosResponse`，导致下载文件内容异常

**Change**

- 为 `httpBlob` 对应的 `axiosBlobInstance` 增加请求拦截器，请求时自动携带当前登录态 `Authorization`
- 为 `axiosBlobInstance` 增加响应拦截器