### PR TITLE
Feat/multi route origin

### DIFF
--- a/webview/src/helper/utils.ts
+++ b/webview/src/helper/utils.ts
@@ -1,4 +1,12 @@
-import type { ApisixRoute, ApisixUpstreamConfig } from '@/service/types'
+import type {
+    ApisixRoute,
+    ApisixRouteUpstreamFormNode,
+    ApisixRouteUpstreamMode,
+    ApisixUpstreamConfig,
+    ApisixUpstreamHashOn,
+    ApisixUpstreamType,
+    ApisixUpstreamNode
+} from '@/service/types'
 
 // 全局自动刷新间隔（毫秒），所有轮询定时器统一使用此常量
 export const POLL_INTERVAL = 3000
@@ -69,33 +77,83 @@ export const formatFileSize = (bytes: number): string => {
     return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i]
 }
 
-export interface UpstreamNodeItem {
-    host: string
-    port: string
-    weight: number
+const parseNodeKey = (key: string): ApisixUpstreamNode => {
+    if (!key) return { host: '', port: '' }
+    const idx = key.lastIndexOf(':')
+    if (idx <= 0) return { host: key, port: '' }
+    const port = key.slice(idx + 1)
+    return {
+        host: key.slice(0, idx),
+        port: /^\d+$/.test(port) ? Number(port) : port
+    }
 }
 
-const DEFAULT_UPSTREAM_TYPE = 'roundrobin'
+const DEFAULT_UPSTREAM_TYPE: ApisixUpstreamType = 'roundrobin'
 
-export const parseUpstreamNodes = (upstream?: ApisixUpstreamConfig): { type: string; nodes: UpstreamNodeItem[] } => {
-    const type = upstream?.type || DEFAULT_UPSTREAM_TYPE
+export const normalizeUpstreamType = (type?: string): ApisixUpstreamType => {
+    if (type === 'chash' || type === 'ewma' || type === 'least_conn') return type
+    return DEFAULT_UPSTREAM_TYPE
+}
+
+export const normalizeUpstreamNodes = (upstream?: ApisixUpstreamConfig): ApisixUpstreamNode[] => {
     const nodes = upstream?.nodes
-    if (!nodes) return { type, nodes: [] }
-    if (Array.isArray(nodes) && nodes.length > 0) {
-        return {
-            type,
-            nodes: nodes.map(n => ({ host: n.host || '', port: String(n.port || ''), weight: n.weight ?? 1 }))
-        }
+    if (!nodes) return []
+
+    if (Array.isArray(nodes)) {
+        return nodes
+            .map(node => ({
+                host: node.host || '',
+                port: node.port || '',
+                weight: typeof node.weight === 'number' && node.weight >= 0 ? node.weight : 1
+            }))
+            .filter(node => node.host || node.port)
     }
+
     if (typeof nodes === 'object') {
-        const result: UpstreamNodeItem[] = []
-        for (const [k, w] of Object.entries(nodes)) {
-            const i = k.lastIndexOf(':')
-            result.push({ host: i > 0 ? k.slice(0, i) : k, port: i > 0 ? k.slice(i + 1) : '', weight: (w as number) ?? 1 })
-        }
-        return { type, nodes: result }
+        return Object.entries(nodes).map(([key, weight]) => {
+            const parsed = parseNodeKey(key)
+            return {
+                ...parsed,
+                weight: typeof weight === 'number' && weight >= 0 ? weight : 1
+            }
+        })
     }
-    return { type, nodes: [] }
+
+    return []
+}
+
+export const parseUpstreamNode = (upstream?: ApisixUpstreamConfig): { host: string; port: number | string } => {
+    const [first] = normalizeUpstreamNodes(upstream)
+    return { host: first?.host || '', port: first?.port || '' }
+}
+
+export const normalizeUpstreamFormNodes = (upstream?: ApisixUpstreamConfig): ApisixRouteUpstreamFormNode[] => {
+    const nodes = normalizeUpstreamNodes(upstream).map(node => ({
+        host: String(node.host || ''),
+        port: String(node.port || ''),
+        weight: typeof node.weight === 'number' && node.weight >= 0 ? node.weight : 1
+    }))
+
+    return nodes.length > 0 ? nodes : [{ host: '', port: '', weight: 1 }]
+}
+
+export const detectRouteUpstreamMode = (route?: Pick<ApisixRoute, 'upstream_id' | 'upstream'>): ApisixRouteUpstreamMode => {
+    if (route?.upstream_id) return 'upstream_id'
+    if (normalizeUpstreamNodes(route?.upstream).length > 0) return 'nodes'
+    return 'none'
+}
+
+export const formatRouteUpstreamSummary = (route: Pick<ApisixRoute, 'upstream_id' | 'upstream'>): string => {
+    if (route.upstream_id) return `引用上游 #${route.upstream_id}`
+
+    const nodes = normalizeUpstreamNodes(route.upstream)
+    if (nodes.length === 0) return '未配置'
+
+    const upstreamType = normalizeUpstreamType(route.upstream?.type)
+    const first = nodes[0]
+    const firstLabel = `${first.host || '-'}:${first.port || '-'}`
+    if (nodes.length === 1) return `${upstreamType} · ${firstLabel}`
+    return `${upstreamType} · ${firstLabel} 等 ${nodes.length} 个节点`
 }
 
 interface RouteFormData {
@@ -108,14 +166,58 @@ interface RouteFormData {
     plugins?: Record<string, unknown>
     uris: string
     hosts: string
-    upstream_nodes: UpstreamNodeItem[]
-    upstream_type: string
+    upstream_mode: ApisixRouteUpstreamMode
+    upstream_type?: ApisixUpstreamType
+    upstream_id?: string
+    upstream_nodes: ApisixRouteUpstreamFormNode[]
+    upstream_hash_on?: ApisixUpstreamHashOn
+    upstream_key?: string
     timeout_connect?: string | number
     timeout_send?: string | number
     timeout_read?: string | number
 }
 
-export const buildRoutePayload = (formData: RouteFormData): ApisixRoute => {
+const buildInlineUpstream = (
+    nodes: ApisixRouteUpstreamFormNode[],
+    baseUpstream?: ApisixUpstreamConfig | null,
+    hashOn?: ApisixUpstreamHashOn,
+    key?: string
+): ApisixUpstreamConfig | undefined => {
+    const normalizedNodes = nodes
+        .map(node => ({
+            host: node.host.trim(),
+            port: String(node.port).trim(),
+            weight: Number(node.weight) >= 0 ? Number(node.weight) : 1
+        }))
+        .filter(node => node.host && node.port)
+        .map(node => ({
+            host: node.host,
+            port: Number(node.port),
+            weight: node.weight
+        }))
+
+    if (normalizedNodes.length === 0) return undefined
+
+    const type = String(baseUpstream?.type || 'roundrobin')
+    const result: ApisixUpstreamConfig = {
+        ...(baseUpstream || {}),
+        type,
+        nodes: normalizedNodes
+    }
+
+    if (type === 'chash') {
+        result.hash_on = hashOn || 'vars'
+        result.key = key || 'remote_addr'
+    } else {
+        // 非 chash 策略不传 hash_on / key
+        delete result.hash_on
+        delete result.key
+    }
+
+    return result
+}
+
+export const buildRoutePayload = (formData: RouteFormData, baseUpstream?: ApisixUpstreamConfig | null): ApisixRoute => {
     const payload: ApisixRoute = {
         name: formData.name.trim(),
         desc: formData.desc.trim(),
@@ -131,19 +233,31 @@ export const buildRoutePayload = (formData: RouteFormData): ApisixRoute => {
     const hostsArr = formData.hosts.split('\n').map((s: string) => s.trim()).filter(Boolean)
     if (hostsArr.length > 1) payload.hosts = hostsArr
     else if (hostsArr.length === 1) payload.host = hostsArr[0]
-    const validNodes = formData.upstream_nodes.filter(n => n.host.trim() && String(n.port).trim())
-    if (validNodes.length > 0) {
-        payload.upstream = {
-            type: formData.upstream_type || 'roundrobin',
-            nodes: validNodes.map(n => ({ host: n.host.trim(), port: Number(n.port), weight: n.weight ?? 1 }))
-        }
+
+    if (formData.upstream_mode === 'upstream_id' && formData.upstream_id?.trim()) {
+        payload.upstream_id = formData.upstream_id.trim()
     }
+
+    if (formData.upstream_mode === 'nodes') {
+        const inlineUpstream = buildInlineUpstream(
+            formData.upstream_nodes,
+            {
+                ...(baseUpstream || {}),
+                type: normalizeUpstreamType(formData.upstream_type || baseUpstream?.type)
+            },
+            formData.upstream_hash_on,
+            formData.upstream_key
+        )
+        if (inlineUpstream) payload.upstream = inlineUpstream
+    }
+
     const connect = Number(formData.timeout_connect) || 0
     const send = Number(formData.timeout_send) || 0
     const read = Number(formData.timeout_read) || 0
     if (connect > 0 || send > 0 || read > 0) {
         payload.timeout = { connect: connect || undefined, send: send || undefined, read: read || undefined }
     }
+
     return payload
 }
 

--- a/webview/src/helper/utils.ts
+++ b/webview/src/helper/utils.ts
@@ -183,33 +183,21 @@ const buildInlineUpstream = (
     hashOn?: ApisixUpstreamHashOn,
     key?: string
 ): ApisixUpstreamConfig | undefined => {
-    const normalizedNodes = nodes
-        .map(node => ({
-            host: node.host.trim(),
-            port: String(node.port).trim(),
-            weight: Number(node.weight) >= 0 ? Number(node.weight) : 1
-        }))
-        .filter(node => node.host && node.port)
-        .map(node => ({
-            host: node.host,
-            port: Number(node.port),
-            weight: node.weight
-        }))
-
-    if (normalizedNodes.length === 0) return undefined
+    const normalizedNodes: { host: string; port: number; weight: number }[] = []
+    for (const node of nodes) {
+        const host = node.host.trim()
+        const port = String(node.port).trim()
+        if (host && port) normalizedNodes.push({ host, port: Number(port), weight: Number(node.weight) >= 0 ? Number(node.weight) : 1 })
+    }
+    if (!normalizedNodes.length) return undefined
 
     const type = String(baseUpstream?.type || 'roundrobin')
-    const result: ApisixUpstreamConfig = {
-        ...(baseUpstream || {}),
-        type,
-        nodes: normalizedNodes
-    }
+    const result: ApisixUpstreamConfig = { ...(baseUpstream || {}), type, nodes: normalizedNodes }
 
     if (type === 'chash') {
         result.hash_on = hashOn || 'vars'
         result.key = key || 'remote_addr'
     } else {
-        // 非 chash 策略不传 hash_on / key
         delete result.hash_on
         delete result.key
     }

--- a/webview/src/service/types/apisix.ts
+++ b/webview/src/service/types/apisix.ts
@@ -1,5 +1,11 @@
 // ─── Apisix 相关 ───
 
+export type ApisixRouteUpstreamMode = 'none' | 'nodes' | 'upstream_id'
+
+export type ApisixUpstreamType = 'roundrobin' | 'chash' | 'ewma' | 'least_conn'
+
+export type ApisixUpstreamHashOn = 'vars' | 'header' | 'cookie' | 'consumer' | 'vars_combinations'
+
 export interface ApisixUpstreamNode {
     host?: string
     port?: number | string
@@ -7,8 +13,10 @@ export interface ApisixUpstreamNode {
 }
 
 export interface ApisixUpstreamConfig {
-    type?: string
+    type?: ApisixUpstreamType | string
     nodes?: ApisixUpstreamNode[] | Record<string, number>
+    hash_on?: ApisixUpstreamHashOn
+    key?: string
     [key: string]: unknown
 }
 
@@ -16,6 +24,20 @@ export interface ApisixRouteTimeout {
     connect?: number
     send?: number
     read?: number
+}
+
+export interface ApisixRouteUpstreamFormNode {
+    host: string
+    port: string
+    weight: number
+}
+
+export interface ApisixRouteUpstreamModeCard {
+    value: ApisixRouteUpstreamMode
+    title: string
+    desc: string
+    icon: string
+    tone: 'indigo' | 'emerald' | 'slate'
 }
 
 export interface ApisixRoute {

--- a/webview/src/views/apisix/routes.vue
+++ b/webview/src/views/apisix/routes.vue
@@ -7,6 +7,8 @@ import type { AppActions } from '@/store/state'
 import api from '@/service/api'
 import type { ApisixRoute } from '@/service/types'
 
+import { formatRouteUpstreamSummary, normalizeUpstreamNodes } from '@/helper/utils'
+
 import RouteEditModal from '@/views/apisix/widget/route-edit-modal.vue'
 
 @Component({
@@ -27,13 +29,17 @@ class Routes extends Vue {
     get filteredRoutes() {
         if (!this.searchText) return this.routes
         const s = this.searchText.toLowerCase()
-        return this.routes.filter((r: ApisixRoute) =>
-            (r.name || '').toLowerCase().includes(s) ||
-            (r.id || '').toLowerCase().includes(s) ||
-            (r.uri || '').toLowerCase().includes(s) ||
-            (r.uris || []).some((u: string) => u.toLowerCase().includes(s)) ||
-            (r.desc || '').toLowerCase().includes(s)
-        )
+        return this.routes.filter((r: ApisixRoute) => {
+            const upstreamSummary = this.getRouteUpstreamSummary(r).toLowerCase()
+            return (
+                (r.name || '').toLowerCase().includes(s) ||
+                (r.id || '').toLowerCase().includes(s) ||
+                (r.uri || '').toLowerCase().includes(s) ||
+                (r.uris || []).some((u: string) => u.toLowerCase().includes(s)) ||
+                (r.desc || '').toLowerCase().includes(s) ||
+                upstreamSummary.includes(s)
+            )
+        })
     }
 
     // ─── 方法 ───
@@ -74,6 +80,16 @@ class Routes extends Vue {
 
     getRouteHost(r: ApisixRoute) {
         return r.hosts?.length ? r.hosts.join(', ') : (r.host || '*')
+    }
+
+    getRouteUpstreamSummary(r: ApisixRoute) {
+        return formatRouteUpstreamSummary(r)
+    }
+
+    getRouteUpstreamTagClass(r: ApisixRoute) {
+        if (r.upstream_id) return 'bg-emerald-50 text-emerald-700'
+        if (normalizeUpstreamNodes(r.upstream).length > 0) return 'bg-indigo-50 text-indigo-700'
+        return 'bg-slate-100 text-slate-500'
     }
 
     toggleStatus(route: ApisixRoute) {
@@ -124,30 +140,32 @@ export default toNative(Routes)
 
 <template>
   <div>
-    <div class="card mb-4">
+    <div class="card mb-4 overflow-hidden">
       <div class="bg-slate-50 border-b border-slate-200 rounded-t-2xl px-4 md:px-6 py-3">
-        <!-- 桌面端 -->
         <div class="hidden md:flex items-center justify-between">
           <div class="flex items-center gap-3">
-            <div class="w-9 h-9 rounded-lg bg-indigo-500 flex items-center justify-center"><i class="fas fa-route text-white"></i></div>
-            <div><h1 class="text-lg font-semibold text-slate-800">路由管理</h1><p class="text-xs text-slate-500">管理 APISIX 路由</p></div>
+            <div class="w-9 h-9 rounded-lg bg-indigo-500 flex items-center justify-center shadow-sm"><i class="fas fa-route text-white"></i></div>
+            <div>
+              <h1 class="text-lg font-semibold text-slate-800">路由管理</h1>
+              <p class="text-xs text-slate-500">管理 APISIX 路由，并支持单路由配置多个上游节点或引用已有上游</p>
+            </div>
           </div>
           <div class="flex items-center gap-2">
             <div class="relative">
-              <input v-model="searchText" type="text" placeholder="搜索路由..." class="pl-8 pr-3 py-1.5 text-xs border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent w-48" />
+              <input v-model="searchText" type="text" placeholder="搜索路由、URI、描述或上游..." class="pl-8 pr-3 py-1.5 text-xs border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent w-64 bg-white" />
               <i class="fas fa-search absolute left-2.5 top-1/2 -translate-y-1/2 text-slate-400 text-xs"></i>
             </div>
             <button @click="loadRoutes()" class="px-3 py-1.5 rounded-lg bg-white border border-slate-200 hover:bg-slate-50 text-slate-700 text-xs font-medium flex items-center gap-1.5 transition-colors"><i class="fas fa-rotate"></i>刷新</button>
-            <button v-if="actions.hasPerm('apisix', true)" @click="openCreateModal()" class="px-3 py-1.5 rounded-lg bg-indigo-500 hover:bg-indigo-600 text-white text-xs font-medium flex items-center gap-1.5 transition-colors"><i class="fas fa-plus"></i>创建</button>
+            <button v-if="actions.hasPerm('apisix', true)" @click="openCreateModal()" class="px-3 py-1.5 rounded-lg bg-indigo-500 hover:bg-indigo-600 text-white text-xs font-medium flex items-center gap-1.5 transition-colors shadow-sm"><i class="fas fa-plus"></i>创建</button>
           </div>
         </div>
-        <!-- 移动端 -->
+
         <div class="flex md:hidden items-center justify-between">
           <div class="flex items-center gap-3 min-w-0 flex-1">
-            <div class="w-9 h-9 rounded-lg bg-indigo-500 flex items-center justify-center flex-shrink-0"><i class="fas fa-route text-white"></i></div>
+            <div class="w-9 h-9 rounded-lg bg-indigo-500 flex items-center justify-center flex-shrink-0 shadow-sm"><i class="fas fa-route text-white"></i></div>
             <div class="min-w-0">
               <h1 class="text-lg font-semibold text-slate-800 truncate">路由管理</h1>
-              <p class="text-xs text-slate-500 truncate">管理 APISIX 路由</p>
+              <p class="text-xs text-slate-500 truncate">支持多上游节点与已有上游引用</p>
             </div>
           </div>
           <div class="flex items-center gap-1 flex-shrink-0">
@@ -160,30 +178,38 @@ export default toNative(Routes)
           </div>
         </div>
       </div>
-      <!-- 移动端搜索栏 -->
-      <div class="md:hidden px-4 py-2 border-b border-slate-100">
+
+      <div class="md:hidden px-4 py-2 border-b border-slate-100 bg-white">
         <div class="relative">
-          <input v-model="searchText" type="text" placeholder="搜索路由..." class="w-full pl-8 pr-3 py-1.5 text-xs border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent" />
+          <input v-model="searchText" type="text" placeholder="搜索路由、URI、上游..." class="w-full pl-8 pr-3 py-1.5 text-xs border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent" />
           <i class="fas fa-search absolute left-2.5 top-1/2 -translate-y-1/2 text-slate-400 text-xs"></i>
         </div>
       </div>
-      <div v-if="loading" class="flex flex-col items-center justify-center py-20"><div class="w-12 h-12 spinner mb-3"></div><p class="text-slate-500">加载中...</p></div>
+
+      <div v-if="loading" class="flex flex-col items-center justify-center py-20">
+        <div class="w-12 h-12 spinner mb-3"></div>
+        <p class="text-slate-500">加载中...</p>
+      </div>
+
       <div v-else-if="filteredRoutes.length === 0" class="flex flex-col items-center justify-center py-20">
         <div class="w-20 h-20 rounded-full bg-slate-100 flex items-center justify-center mb-4"><i class="fas fa-route text-4xl text-slate-300"></i></div>
         <p class="text-slate-600 font-medium mb-1">暂无路由</p>
         <p class="text-sm text-slate-400">点击「创建」添加新路由</p>
       </div>
+
       <div v-else class="space-y-3">
-        <!-- 桌面端表格视图 -->
         <div class="hidden md:block overflow-x-auto">
           <table class="w-full border-collapse">
-            <thead><tr class="bg-slate-50 border-b border-slate-200">
-              <th class="text-left px-4 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wider">名称</th>
-              <th class="text-left px-4 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wider">URI</th>
-              <th class="text-left px-4 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wider">Host</th>
-              <th class="text-left px-4 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wider">状态</th>
-              <th class="w-32 px-4 py-3 text-right text-xs font-semibold text-slate-600 uppercase tracking-wider">操作</th>
-            </tr></thead>
+            <thead>
+              <tr class="bg-slate-50 border-b border-slate-200">
+                <th class="text-left px-4 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wider">名称</th>
+                <th class="text-left px-4 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wider">URI</th>
+                <th class="text-left px-4 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wider">Host</th>
+                <th class="text-left px-4 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wider">上游</th>
+                <th class="text-left px-4 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wider">状态</th>
+                <th class="w-32 px-4 py-3 text-right text-xs font-semibold text-slate-600 uppercase tracking-wider">操作</th>
+              </tr>
+            </thead>
             <tbody class="bg-white divide-y divide-slate-100">
               <tr v-for="route in filteredRoutes" :key="route.id" class="hover:bg-slate-50 transition-colors">
                 <td class="px-4 py-3 max-w-[280px]">
@@ -197,15 +223,21 @@ export default toNative(Routes)
                     </div>
                   </div>
                 </td>
-                <td class="px-4 py-3"><code class="text-xs bg-slate-100 px-2 py-1 rounded text-slate-700">{{ getRouteUri(route) }}</code></td>
-                <td class="px-4 py-3"><span class="text-sm text-slate-600">{{ getRouteHost(route) }}</span></td>
-                <td class="px-4 py-3">
+                <td class="px-4 py-3 align-top"><code class="text-xs bg-slate-100 px-2 py-1 rounded text-slate-700 whitespace-normal break-all">{{ getRouteUri(route) }}</code></td>
+                <td class="px-4 py-3 align-top"><span class="text-sm text-slate-600 break-all">{{ getRouteHost(route) }}</span></td>
+                <td class="px-4 py-3 align-top">
+                  <div :class="['inline-flex items-center gap-2 px-2.5 py-1 rounded-full text-xs font-medium max-w-xs', getRouteUpstreamTagClass(route)]">
+                    <i class="fas fa-circle-nodes text-[10px]"></i>
+                    <span class="truncate">{{ getRouteUpstreamSummary(route) }}</span>
+                  </div>
+                </td>
+                <td class="px-4 py-3 align-top">
                   <button @click="toggleStatus(route)" v-if="actions.hasPerm('apisix', true)" :class="['inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium cursor-pointer transition-colors', route.status === 1 ? 'bg-emerald-50 text-emerald-700 hover:bg-emerald-100' : 'bg-slate-100 text-slate-500 hover:bg-slate-200']">
                     <i :class="route.status === 1 ? 'fas fa-circle text-emerald-500' : 'fas fa-circle text-slate-400'" class="text-[6px]"></i>
                     {{ route.status === 1 ? '启用' : '禁用' }}
                   </button>
                 </td>
-                <td class="px-4 py-3">
+                <td class="px-4 py-3 align-top">
                   <div class="flex justify-end items-center gap-1">
                     <button v-if="actions.hasPerm('apisix', true)" @click="openEditModal(route)" class="btn-icon text-indigo-600 hover:bg-indigo-50" title="编辑"><i class="fas fa-pen text-xs"></i></button>
                     <button v-if="actions.hasPerm('apisix', true)" @click="deleteRoute(route)" class="btn-icon text-red-600 hover:bg-red-50" title="删除"><i class="fas fa-trash text-xs"></i></button>
@@ -216,17 +248,15 @@ export default toNative(Routes)
           </table>
         </div>
 
-        <!-- 移动端卡片视图 -->
         <div class="md:hidden space-y-3 p-4">
-          <div 
-            v-for="route in filteredRoutes" 
+          <div
+            v-for="route in filteredRoutes"
             :key="route.id"
             class="rounded-xl border border-slate-200 bg-white p-4 transition-all hover:shadow-sm"
           >
-            <!-- 顶部：路由信息和状态 -->
             <div class="flex items-center justify-between mb-3">
               <div class="flex items-center gap-3 min-w-0 flex-1">
-                <div class="w-10 h-10 rounded-lg bg-indigo-400 flex items-center justify-center flex-shrink-0">
+                <div class="w-10 h-10 rounded-lg bg-indigo-400 flex items-center justify-center flex-shrink-0 shadow-sm">
                   <i class="fas fa-route text-white text-base"></i>
                 </div>
                 <div class="min-w-0">
@@ -239,19 +269,22 @@ export default toNative(Routes)
                 {{ route.status === 1 ? '启用' : '禁用' }}
               </button>
             </div>
-            
-            <!-- 中间：URI和Host信息 -->
+
             <div class="flex items-start gap-2 mb-3">
               <span class="text-xs text-slate-400 flex-shrink-0 mt-0.5">URI</span>
               <code class="text-xs bg-slate-100 px-2 py-1 rounded text-slate-700 break-all">{{ getRouteUri(route) }}</code>
             </div>
-            
-            <div class="flex items-center gap-2 mb-3">
+
+            <div class="flex items-center gap-2 mb-2">
               <span class="text-xs text-slate-400 flex-shrink-0">Host</span>
               <span class="text-xs text-slate-600 break-all">{{ getRouteHost(route) }}</span>
             </div>
-            
-            <!-- 底部：操作按钮 -->
+
+            <div class="flex items-center gap-2 mb-3">
+              <span class="text-xs text-slate-400 flex-shrink-0">上游</span>
+              <span :class="['text-xs px-2 py-1 rounded-full break-all', getRouteUpstreamTagClass(route)]">{{ getRouteUpstreamSummary(route) }}</span>
+            </div>
+
             <div class="flex flex-wrap gap-1 pt-2 border-t border-slate-100">
               <button v-if="actions.hasPerm('apisix', true)" @click="openEditModal(route)" class="btn-icon text-indigo-600 hover:bg-indigo-50" title="编辑">
                 <i class="fas fa-pen text-xs"></i><span class="text-xs ml-1">编辑</span>

--- a/webview/src/views/apisix/routes.vue
+++ b/webview/src/views/apisix/routes.vue
@@ -140,29 +140,27 @@ export default toNative(Routes)
 
 <template>
   <div>
-    <div class="card mb-4 overflow-hidden">
+    <div class="card mb-4">
       <div class="bg-slate-50 border-b border-slate-200 rounded-t-2xl px-4 md:px-6 py-3">
+        <!-- 桌面端 -->
         <div class="hidden md:flex items-center justify-between">
           <div class="flex items-center gap-3">
-            <div class="w-9 h-9 rounded-lg bg-indigo-500 flex items-center justify-center shadow-sm"><i class="fas fa-route text-white"></i></div>
-            <div>
-              <h1 class="text-lg font-semibold text-slate-800">路由管理</h1>
-              <p class="text-xs text-slate-500">管理 APISIX 路由，并支持单路由配置多个上游节点或引用已有上游</p>
-            </div>
+            <div class="w-9 h-9 rounded-lg bg-indigo-500 flex items-center justify-center"><i class="fas fa-route text-white"></i></div>
+            <div><h1 class="text-lg font-semibold text-slate-800">路由管理</h1><p class="text-xs text-slate-500">管理 APISIX 路由，并支持多上游节点或引用已有上游</p></div>
           </div>
           <div class="flex items-center gap-2">
             <div class="relative">
-              <input v-model="searchText" type="text" placeholder="搜索路由、URI、描述或上游..." class="pl-8 pr-3 py-1.5 text-xs border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent w-64 bg-white" />
+              <input v-model="searchText" type="text" placeholder="搜索路由、URI、描述或上游..." class="pl-8 pr-3 py-1.5 text-xs border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent w-64" />
               <i class="fas fa-search absolute left-2.5 top-1/2 -translate-y-1/2 text-slate-400 text-xs"></i>
             </div>
             <button @click="loadRoutes()" class="px-3 py-1.5 rounded-lg bg-white border border-slate-200 hover:bg-slate-50 text-slate-700 text-xs font-medium flex items-center gap-1.5 transition-colors"><i class="fas fa-rotate"></i>刷新</button>
-            <button v-if="actions.hasPerm('apisix', true)" @click="openCreateModal()" class="px-3 py-1.5 rounded-lg bg-indigo-500 hover:bg-indigo-600 text-white text-xs font-medium flex items-center gap-1.5 transition-colors shadow-sm"><i class="fas fa-plus"></i>创建</button>
+            <button v-if="actions.hasPerm('apisix', true)" @click="openCreateModal()" class="px-3 py-1.5 rounded-lg bg-indigo-500 hover:bg-indigo-600 text-white text-xs font-medium flex items-center gap-1.5 transition-colors"><i class="fas fa-plus"></i>创建</button>
           </div>
         </div>
-
+        <!-- 移动端 -->
         <div class="flex md:hidden items-center justify-between">
           <div class="flex items-center gap-3 min-w-0 flex-1">
-            <div class="w-9 h-9 rounded-lg bg-indigo-500 flex items-center justify-center flex-shrink-0 shadow-sm"><i class="fas fa-route text-white"></i></div>
+            <div class="w-9 h-9 rounded-lg bg-indigo-500 flex items-center justify-center flex-shrink-0"><i class="fas fa-route text-white"></i></div>
             <div class="min-w-0">
               <h1 class="text-lg font-semibold text-slate-800 truncate">路由管理</h1>
               <p class="text-xs text-slate-500 truncate">支持多上游节点与已有上游引用</p>
@@ -178,38 +176,31 @@ export default toNative(Routes)
           </div>
         </div>
       </div>
-
-      <div class="md:hidden px-4 py-2 border-b border-slate-100 bg-white">
+      <!-- 移动端搜索栏 -->
+      <div class="md:hidden px-4 py-2 border-b border-slate-100">
         <div class="relative">
           <input v-model="searchText" type="text" placeholder="搜索路由、URI、上游..." class="w-full pl-8 pr-3 py-1.5 text-xs border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent" />
           <i class="fas fa-search absolute left-2.5 top-1/2 -translate-y-1/2 text-slate-400 text-xs"></i>
         </div>
       </div>
-
-      <div v-if="loading" class="flex flex-col items-center justify-center py-20">
-        <div class="w-12 h-12 spinner mb-3"></div>
-        <p class="text-slate-500">加载中...</p>
-      </div>
-
+      <div v-if="loading" class="flex flex-col items-center justify-center py-20"><div class="w-12 h-12 spinner mb-3"></div><p class="text-slate-500">加载中...</p></div>
       <div v-else-if="filteredRoutes.length === 0" class="flex flex-col items-center justify-center py-20">
         <div class="w-20 h-20 rounded-full bg-slate-100 flex items-center justify-center mb-4"><i class="fas fa-route text-4xl text-slate-300"></i></div>
         <p class="text-slate-600 font-medium mb-1">暂无路由</p>
         <p class="text-sm text-slate-400">点击「创建」添加新路由</p>
       </div>
-
       <div v-else class="space-y-3">
+        <!-- 桌面端表格视图 -->
         <div class="hidden md:block overflow-x-auto">
           <table class="w-full border-collapse">
-            <thead>
-              <tr class="bg-slate-50 border-b border-slate-200">
-                <th class="text-left px-4 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wider">名称</th>
-                <th class="text-left px-4 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wider">URI</th>
-                <th class="text-left px-4 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wider">Host</th>
-                <th class="text-left px-4 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wider">上游</th>
-                <th class="text-left px-4 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wider">状态</th>
-                <th class="w-32 px-4 py-3 text-right text-xs font-semibold text-slate-600 uppercase tracking-wider">操作</th>
-              </tr>
-            </thead>
+            <thead><tr class="bg-slate-50 border-b border-slate-200">
+              <th class="text-left px-4 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wider">名称</th>
+              <th class="text-left px-4 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wider">URI</th>
+              <th class="text-left px-4 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wider">Host</th>
+              <th class="text-left px-4 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wider">上游</th>
+              <th class="text-left px-4 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wider">状态</th>
+              <th class="w-32 px-4 py-3 text-right text-xs font-semibold text-slate-600 uppercase tracking-wider">操作</th>
+            </tr></thead>
             <tbody class="bg-white divide-y divide-slate-100">
               <tr v-for="route in filteredRoutes" :key="route.id" class="hover:bg-slate-50 transition-colors">
                 <td class="px-4 py-3 max-w-[280px]">
@@ -223,21 +214,16 @@ export default toNative(Routes)
                     </div>
                   </div>
                 </td>
-                <td class="px-4 py-3 align-top"><code class="text-xs bg-slate-100 px-2 py-1 rounded text-slate-700 whitespace-normal break-all">{{ getRouteUri(route) }}</code></td>
-                <td class="px-4 py-3 align-top"><span class="text-sm text-slate-600 break-all">{{ getRouteHost(route) }}</span></td>
-                <td class="px-4 py-3 align-top">
-                  <div :class="['inline-flex items-center gap-2 px-2.5 py-1 rounded-full text-xs font-medium max-w-xs', getRouteUpstreamTagClass(route)]">
-                    <i class="fas fa-circle-nodes text-[10px]"></i>
-                    <span class="truncate">{{ getRouteUpstreamSummary(route) }}</span>
-                  </div>
-                </td>
-                <td class="px-4 py-3 align-top">
+                <td class="px-4 py-3"><code class="text-xs bg-slate-100 px-2 py-1 rounded text-slate-700 break-all">{{ getRouteUri(route) }}</code></td>
+                <td class="px-4 py-3"><span class="text-sm text-slate-600 break-all">{{ getRouteHost(route) }}</span></td>
+                <td class="px-4 py-3"><span :class="['text-xs px-2 py-1 rounded break-all', getRouteUpstreamTagClass(route)]">{{ getRouteUpstreamSummary(route) }}</span></td>
+                <td class="px-4 py-3">
                   <button @click="toggleStatus(route)" v-if="actions.hasPerm('apisix', true)" :class="['inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium cursor-pointer transition-colors', route.status === 1 ? 'bg-emerald-50 text-emerald-700 hover:bg-emerald-100' : 'bg-slate-100 text-slate-500 hover:bg-slate-200']">
                     <i :class="route.status === 1 ? 'fas fa-circle text-emerald-500' : 'fas fa-circle text-slate-400'" class="text-[6px]"></i>
                     {{ route.status === 1 ? '启用' : '禁用' }}
                   </button>
                 </td>
-                <td class="px-4 py-3 align-top">
+                <td class="px-4 py-3">
                   <div class="flex justify-end items-center gap-1">
                     <button v-if="actions.hasPerm('apisix', true)" @click="openEditModal(route)" class="btn-icon text-indigo-600 hover:bg-indigo-50" title="编辑"><i class="fas fa-pen text-xs"></i></button>
                     <button v-if="actions.hasPerm('apisix', true)" @click="deleteRoute(route)" class="btn-icon text-red-600 hover:bg-red-50" title="删除"><i class="fas fa-trash text-xs"></i></button>
@@ -248,15 +234,17 @@ export default toNative(Routes)
           </table>
         </div>
 
+        <!-- 移动端卡片视图 -->
         <div class="md:hidden space-y-3 p-4">
           <div
             v-for="route in filteredRoutes"
             :key="route.id"
             class="rounded-xl border border-slate-200 bg-white p-4 transition-all hover:shadow-sm"
           >
+            <!-- 顶部：路由信息和状态 -->
             <div class="flex items-center justify-between mb-3">
               <div class="flex items-center gap-3 min-w-0 flex-1">
-                <div class="w-10 h-10 rounded-lg bg-indigo-400 flex items-center justify-center flex-shrink-0 shadow-sm">
+                <div class="w-10 h-10 rounded-lg bg-indigo-400 flex items-center justify-center flex-shrink-0">
                   <i class="fas fa-route text-white text-base"></i>
                 </div>
                 <div class="min-w-0">
@@ -270,6 +258,7 @@ export default toNative(Routes)
               </button>
             </div>
 
+            <!-- 中间：URI和Host信息 -->
             <div class="flex items-start gap-2 mb-3">
               <span class="text-xs text-slate-400 flex-shrink-0 mt-0.5">URI</span>
               <code class="text-xs bg-slate-100 px-2 py-1 rounded text-slate-700 break-all">{{ getRouteUri(route) }}</code>
@@ -285,6 +274,7 @@ export default toNative(Routes)
               <span :class="['text-xs px-2 py-1 rounded-full break-all', getRouteUpstreamTagClass(route)]">{{ getRouteUpstreamSummary(route) }}</span>
             </div>
 
+            <!-- 底部：操作按钮 -->
             <div class="flex flex-wrap gap-1 pt-2 border-t border-slate-100">
               <button v-if="actions.hasPerm('apisix', true)" @click="openEditModal(route)" class="btn-icon text-indigo-600 hover:bg-indigo-50" title="编辑">
                 <i class="fas fa-pen text-xs"></i><span class="text-xs ml-1">编辑</span>

--- a/webview/src/views/apisix/widget/route-edit-modal.vue
+++ b/webview/src/views/apisix/widget/route-edit-modal.vue
@@ -1,18 +1,34 @@
 <script lang="ts">
-import HostSelect from './host-select.vue'
-import PortSelect from './port-select.vue'
-import { Component, Inject, Vue, Watch, toNative } from 'vue-facing-decorator'
+import { Component, Inject, Vue, toNative } from 'vue-facing-decorator'
 
 import { APP_ACTIONS_KEY } from '@/store/state'
 import type { AppActions } from '@/store/state'
 
 import api from '@/service/api'
-import type { ApisixRoute, ApisixPluginConfig, ApisixUpstream, DockerContainerInfo } from '@/service/types'
+import type {
+    ApisixPluginConfig,
+    ApisixRoute,
+    ApisixRouteUpstreamFormNode,
+    ApisixRouteUpstreamModeCard,
+    ApisixRouteUpstreamMode,
+    ApisixUpstream,
+    ApisixUpstreamConfig,
+    ApisixUpstreamHashOn,
+    ApisixUpstreamType,
+    DockerContainerInfo
+} from '@/service/types'
 
-import { parseUpstreamNodes, buildRoutePayload } from '@/helper/utils'
-import type { UpstreamNodeItem } from '@/helper/utils'
+import {
+    buildRoutePayload,
+    detectRouteUpstreamMode,
+    normalizeUpstreamFormNodes,
+    normalizeUpstreamType
+} from '@/helper/utils'
 
 import BaseModal from '@/component/modal.vue'
+
+import HostSelect from './host-select.vue'
+import PortSelect from './port-select.vue'
 
 @Component({
     expose: ['show'],
@@ -34,8 +50,7 @@ class RouteEditModal extends Vue {
     importRoutePluginsLoading = false
     selectedImportPlugins: Set<string> = new Set()
     pluginSearchKeyword = ''
-    suppressPortAutofill = false
-    originalUpstream: Record<string, unknown> | null = null
+    originalUpstream: ApisixUpstreamConfig | null = null
 
     pluginConfigs: ApisixPluginConfig[] = []
     upstreams: ApisixUpstream[] = []
@@ -44,15 +59,32 @@ class RouteEditModal extends Vue {
     routes: ApisixRoute[] = []
 
     formData = {
-        name: '', desc: '', uris: '', hosts: '',
-        status: 1, priority: 0, enable_websocket: false,
-        plugin_config_id: '', upstream_nodes: [] as UpstreamNodeItem[], upstream_type: 'roundrobin',
-        timeout_connect: '', timeout_send: '', timeout_read: '',
-        plugins: {} as Record<string, unknown>, pluginsJson: '{}', pluginsJsonError: ''
+        name: '',
+        desc: '',
+        uris: '',
+        hosts: '',
+        status: 1,
+        priority: 0,
+        enable_websocket: false,
+        plugin_config_id: '',
+        plugins: {} as Record<string, unknown>,
+        pluginsJson: '{}',
+        pluginsJsonError: '',
+        upstream_mode: 'nodes' as ApisixRouteUpstreamMode,
+        upstream_type: 'roundrobin' as ApisixUpstreamType,
+        upstream_id: '',
+        upstream_nodes: [{ host: '', port: '', weight: 1 }] as ApisixRouteUpstreamFormNode[],
+        upstream_hash_on: 'vars' as ApisixUpstreamHashOn,
+        upstream_key: 'remote_addr',
+        timeout_connect: '' as string | number,
+        timeout_send: '' as string | number,
+        timeout_read: '' as string | number
     }
 
     // ─── 计算属性 ───
-    get currentPluginNames() { return Object.keys(this.formData.plugins || {}) }
+    get currentPluginNames() {
+        return Object.keys(this.formData.plugins || {})
+    }
 
     get filteredAvailablePlugins() {
         const all = Object.keys(this.availablePlugins)
@@ -60,52 +92,112 @@ class RouteEditModal extends Vue {
         return all.filter(n => n.toLowerCase().includes(this.pluginSearchKeyword.toLowerCase()))
     }
 
-    // ─── 监听器 ───
-    // 当第一个节点的 host 变化时，自动同步该容器的第一个端口
-    prevHost0 = ''
-    @Watch('formData.upstream_nodes.0.host')
-    onUpstreamHostChange() {
-        const node = this.formData.upstream_nodes[0]
-        if (!node) return
-        const host = node.host?.trim() || ''
-        // 仅在 host 实际变化时才自动填充端口
-        if (host === this.prevHost0) return
-        this.prevHost0 = host
-        if (this.suppressPortAutofill) {
-            this.suppressPortAutofill = false
-            return
+    get selectedInlineNodeCount() {
+        return this.formData.upstream_nodes.filter(node => node.host.trim() && String(node.port).trim()).length
+    }
+
+    get upstreamModeCards(): ApisixRouteUpstreamModeCard[] {
+        return [
+            {
+                value: 'nodes',
+                title: '内联多上游节点',
+                desc: '一个路由直连多个节点，并为每个节点设置权重',
+                icon: 'fa-circle-nodes',
+                tone: 'indigo'
+            },
+            {
+                value: 'upstream_id',
+                title: '引用已有上游',
+                desc: '复用 APISIX 中已经创建好的上游对象',
+                icon: 'fa-diagram-project',
+                tone: 'emerald'
+            },
+            {
+                value: 'none',
+                title: '空上游',
+                desc: '暂不配置转发目标，先保存路由规则',
+                icon: 'fa-ban',
+                tone: 'slate'
+            },
+        ]
+    }
+
+    get upstreamTypeOptions(): Array<{ value: ApisixUpstreamType; label: string; desc: string }> {
+        return [
+            { value: 'roundrobin', label: 'roundrobin', desc: '按权重轮询分配请求' },
+            { value: 'least_conn', label: 'least_conn', desc: '优先选择当前连接数更少的节点' },
+            { value: 'ewma', label: 'ewma', desc: '根据历史延迟动态选择更快的节点' },
+            { value: 'chash', label: 'chash', desc: '一致性哈希，适合会话粘性场景' }
+        ]
+    }
+
+    get hashOnOptions(): Array<{ value: ApisixUpstreamHashOn; label: string; keyPlaceholder: string; keyHint: string }> {
+        return [
+            { value: 'vars',             label: 'vars（Nginx 变量）',    keyPlaceholder: 'remote_addr',  keyHint: 'Nginx 变量名，不带 $ 前缀，如 remote_addr、uri' },
+            { value: 'header',           label: 'header（请求头）',      keyPlaceholder: 'X-User-Id',    keyHint: '请求头名称，如 X-User-Id' },
+            { value: 'cookie',           label: 'cookie',               keyPlaceholder: 'session_id',   keyHint: 'Cookie 名称（大小写敏感），如 session_id' },
+            { value: 'consumer',         label: 'consumer（消费者）',    keyPlaceholder: 'consumer_name', keyHint: '通常填 consumer_name，由 APISIX 自动注入' },
+            { value: 'vars_combinations', label: 'vars_combinations',   keyPlaceholder: '$remote_addr$uri', keyHint: '多个 Nginx 变量组合，如 $remote_addr$uri' },
+        ]
+    }
+
+    get selectedHashOnOption() {
+        return this.hashOnOptions.find(o => o.value === this.formData.upstream_hash_on) || this.hashOnOptions[0]
+    }
+
+    get selectedUpstreamTypeOption() {
+        return this.upstreamTypeOptions.find(option => option.value === this.formData.upstream_type) || this.upstreamTypeOptions[0]
+    }
+
+    get routeValidationMessage() {
+        if (this.formData.upstream_mode === 'upstream_id') {
+            return this.formData.upstream_id.trim() ? '' : '请选择要引用的上游对象'
         }
-        const container = this.containers.find(c => c.name === host)
-        if (!container) return
-        const first = container.ports?.[0] || ''
-        node.port = first.split('/')[0].split(':').pop() || ''
-    }
 
-    // ─── 上游节点管理 ───
-    addUpstreamNode() {
-        this.formData.upstream_nodes = [...this.formData.upstream_nodes, { host: '', port: '', weight: 0 }]
-    }
+        if (this.formData.upstream_mode !== 'nodes') return ''
 
-    removeUpstreamNode(index: number) {
-        const nodes = [...this.formData.upstream_nodes]
-        nodes.splice(index, 1)
-        this.formData.upstream_nodes = nodes
-    }
+        const rows = this.formData.upstream_nodes
+        const validRows = rows.filter(node => node.host.trim() && String(node.port).trim())
+        if (validRows.length === 0) return '请至少配置一个完整的上游节点'
 
-    getContainerPortsForNode(index: number): string[] {
-        const node = this.formData.upstream_nodes[index]
-        if (!node) return []
-        const container = this.containers.find(c => c.name === node.host?.trim())
-        return container?.ports || []
+        for (const [index, node] of rows.entries()) {
+            const hasHost = !!node.host.trim()
+            const hasPort = !!String(node.port).trim()
+            if (hasHost !== hasPort) return `第 ${index + 1} 个上游节点的主机和端口需要同时填写`
+            if (hasPort && !/^\d+$/.test(String(node.port).trim())) return `第 ${index + 1} 个上游节点端口必须为数字`
+            if ((hasHost || hasPort) && Number(node.weight) < 0) return `第 ${index + 1} 个上游节点权重不能为负数`
+        }
+
+        if (this.formData.upstream_type === 'chash' && !this.formData.upstream_key?.trim()) {
+            return '使用 chash 策略时，哈希键（key）不能为空'
+        }
+
+        return ''
     }
 
     // ─── 方法 ───
     resetForm() {
         Object.assign(this.formData, {
-            name: '', desc: '', uris: '', hosts: '', status: 1, priority: 0,
-            enable_websocket: false, plugin_config_id: '', upstream_nodes: [{ host: '', port: '', weight: 0 }], upstream_type: 'roundrobin',
-            timeout_connect: '', timeout_send: '', timeout_read: '',
-            plugins: {}, pluginsJson: '{}', pluginsJsonError: ''
+            name: '',
+            desc: '',
+            uris: '',
+            hosts: '',
+            status: 1,
+            priority: 0,
+            enable_websocket: false,
+            plugin_config_id: '',
+            plugins: {},
+            pluginsJson: '{}',
+            pluginsJsonError: '',
+            upstream_mode: 'nodes',
+            upstream_type: 'roundrobin',
+            upstream_id: '',
+            upstream_nodes: [{ host: '', port: '', weight: 1 }],
+            upstream_hash_on: 'vars',
+            upstream_key: 'remote_addr',
+            timeout_connect: '',
+            timeout_send: '',
+            timeout_read: ''
         })
         this.editingRouteId = ''
         this.originalUpstream = null
@@ -114,14 +206,72 @@ class RouteEditModal extends Vue {
         this.importRouteId = ''
         this.importRoutePlugins = {}
         this.selectedImportPlugins = new Set()
-        this.prevHost0 = ''
+        this.pluginSearchKeyword = ''
+    }
+
+    createUpstreamNode(node?: Partial<ApisixRouteUpstreamFormNode>): ApisixRouteUpstreamFormNode {
+        return {
+            host: node?.host || '',
+            port: String(node?.port || ''),
+            weight: Number(node?.weight) >= 0 ? Number(node?.weight) : 1
+        }
+    }
+
+    addUpstreamNode(node?: Partial<ApisixRouteUpstreamFormNode>) {
+        this.formData.upstream_nodes = [...this.formData.upstream_nodes, this.createUpstreamNode(node)]
+    }
+
+    removeUpstreamNode(index: number) {
+        const next = this.formData.upstream_nodes.filter((_, idx) => idx !== index)
+        this.formData.upstream_nodes = next.length > 0 ? next : [this.createUpstreamNode()]
+    }
+
+    setUpstreamMode(mode: ApisixRouteUpstreamMode) {
+        this.formData.upstream_mode = mode
+        if (mode === 'nodes' && this.formData.upstream_nodes.length === 0) {
+            this.formData.upstream_nodes = [this.createUpstreamNode()]
+        }
+    }
+
+    getContainerByHost(host: string) {
+        const normalized = host.trim()
+        return normalized ? this.containers.find(c => c.name === normalized) : undefined
+    }
+
+    getPortsByHost(host: string): string[] {
+        return this.getContainerByHost(host)?.ports || []
+    }
+
+    extractDefaultPort(ports: string[]) {
+        const first = ports[0] || ''
+        return first.split('/')[0].split(':').pop() || ''
+    }
+
+    updateUpstreamNodeHost(index: number, host: string) {
+        const next = [...this.formData.upstream_nodes]
+        const current = next[index]
+        if (!current) return
+        current.host = host
+        const defaultPort = this.extractDefaultPort(this.getPortsByHost(host))
+        if (defaultPort) current.port = defaultPort
+        this.formData.upstream_nodes = next
+    }
+
+    updateUpstreamNodePort(index: number, port: string) {
+        const next = [...this.formData.upstream_nodes]
+        const current = next[index]
+        if (!current) return
+        current.port = port
+        this.formData.upstream_nodes = next
     }
 
     async loadResources(allRoutes: ApisixRoute[]) {
         this.routes = allRoutes || []
         try {
             const [pc, us, pl, ct] = await Promise.all([
-                api.apisixListPluginConfigs(), api.apisixListUpstreams(), api.apisixListPlugins(),
+                api.apisixListPluginConfigs(),
+                api.apisixListUpstreams(),
+                api.apisixListPlugins(),
                 api.listContainers()
             ])
             this.pluginConfigs = pc.payload || []
@@ -134,14 +284,14 @@ class RouteEditModal extends Vue {
     async show(route: ApisixRoute | null, allRoutes: ApisixRoute[]) {
         await this.loadResources(allRoutes)
         if (route && route.id) {
-            const routeId = route.id
+            const routeID = route.id
             this.isEditMode = true
             this.resetForm()
-            this.editingRouteId = routeId
+            this.editingRouteId = routeID
             this.modalLoading = true
             this.isOpen = true
             try {
-                const r = (await api.apisixGetRoute(routeId)).payload
+                const r = (await api.apisixGetRoute(routeID)).payload
                 if (!r) {
                     this.actions.showNotification('error', '加载路由详情失败')
                     this.isOpen = false
@@ -149,37 +299,40 @@ class RouteEditModal extends Vue {
                     return
                 }
                 const plugins = r.plugins || {}
-                const { type: uType, nodes: uNodes } = parseUpstreamNodes(r.upstream)
-                // 保存原始 upstream 配置，提交时若 upstream_nodes 为空则保留
-                this.originalUpstream = r.upstream ? { ...r.upstream as Record<string, unknown> } : null
-                this.suppressPortAutofill = true
+                this.originalUpstream = r.upstream ? { ...(r.upstream as ApisixUpstreamConfig) } : null
                 Object.assign(this.formData, {
-                    name: r.name || '', desc: r.desc || '',
-                    uris: (r.uris?.length ? r.uris : [r.uri || '']).join('\n'),
-                    hosts: (r.hosts?.length ? r.hosts : [r.host || '']).join('\n'),
-                    status: r.status ?? 0, priority: r.priority ?? 0,
+                    name: r.name || '',
+                    desc: r.desc || '',
+                    uris: (r.uris?.length ? r.uris : [r.uri || '']).filter(Boolean).join('\n'),
+                    hosts: (r.hosts?.length ? r.hosts : [r.host || '']).filter(Boolean).join('\n'),
+                    status: r.status ?? 0,
+                    priority: r.priority ?? 0,
                     enable_websocket: r.enable_websocket || false,
                     plugin_config_id: r.plugin_config_id || '',
-                    upstream_nodes: uNodes.length ? uNodes : [{ host: '', port: '', weight: 0 }],
-                    upstream_type: uType,
-                    timeout_connect: r.timeout?.connect ?? '', timeout_send: r.timeout?.send ?? '', timeout_read: r.timeout?.read ?? '',
-                    plugins, pluginsJson: JSON.stringify(plugins, null, 2), pluginsJsonError: ''
+                    plugins,
+                    pluginsJson: JSON.stringify(plugins, null, 2),
+                    pluginsJsonError: '',
+                    upstream_mode: detectRouteUpstreamMode(r),
+                    upstream_type: normalizeUpstreamType(r.upstream?.type),
+                    upstream_id: r.upstream_id || '',
+                    upstream_nodes: normalizeUpstreamFormNodes(r.upstream),
+                    upstream_hash_on: (r.upstream?.hash_on as ApisixUpstreamHashOn) || 'vars',
+                    upstream_key: (r.upstream?.key as string) || 'remote_addr',
+                    timeout_connect: r.timeout?.connect ?? '',
+                    timeout_send: r.timeout?.send ?? '',
+                    timeout_read: r.timeout?.read ?? ''
                 })
-                // 记录初始 host，避免 watcher 误重置端口
-                this.prevHost0 = this.formData.upstream_nodes[0]?.host?.trim() || ''
-                // 若无节点则不需要抑制端口自动填充
-                if (!uNodes.length) this.suppressPortAutofill = false
-            } catch (e) {
+            } catch {
                 this.actions.showNotification('error', '加载路由详情失败')
                 this.isOpen = false
             }
             this.modalLoading = false
-        } else {
-            this.isEditMode = false
-            this.resetForm()
-            this.formData.upstream_nodes = [{ host: '', port: '', weight: 0 }]
-            this.isOpen = true
+            return
         }
+
+        this.isEditMode = false
+        this.resetForm()
+        this.isOpen = true
     }
 
     syncPluginsFromJson() {
@@ -198,7 +351,14 @@ class RouteEditModal extends Vue {
         this.formData.pluginsJson = JSON.stringify(p, null, 2)
     }
 
-    readonly TYPE_DEFAULTS: Record<string, string | number | boolean | unknown[] | Record<string, unknown>> = { string: '', integer: 0, number: 0, boolean: false, array: [], object: {} }
+    readonly TYPE_DEFAULTS: Record<string, string | number | boolean | unknown[] | Record<string, unknown>> = {
+        string: '',
+        integer: 0,
+        number: 0,
+        boolean: false,
+        array: [],
+        object: {}
+    }
 
     buildPluginDefault(schema: { properties?: Record<string, { type: string; default?: unknown }>; required?: string[] }) {
         if (!schema?.properties) return {}
@@ -234,7 +394,7 @@ class RouteEditModal extends Vue {
             const src = (await api.apisixGetRoute(this.importRouteId)).payload?.plugins || {}
             this.importRoutePlugins = src
             this.selectedImportPlugins = new Set(Object.keys(src))
-        } catch (e) {
+        } catch {
             this.actions.showNotification('error', '加载路由插件失败')
         }
         this.importRoutePluginsLoading = false
@@ -263,17 +423,24 @@ class RouteEditModal extends Vue {
         this.actions.showNotification('success', `已导入 ${Object.keys(toImport).length} 个插件`)
     }
 
+    validateInlineNodes() {
+        if (this.routeValidationMessage) {
+            this.actions.showNotification('error', this.routeValidationMessage)
+            return false
+        }
+        return true
+    }
+
     async handleConfirm() {
         if (!this.formData.name.trim()) return this.actions.showNotification('error', '路由名称不能为空')
         if (!this.formData.uris.split('\n').map((s: string) => s.trim()).filter(Boolean).length) return this.actions.showNotification('error', 'URI 不能为空')
         if (this.formData.pluginsJsonError) return this.actions.showNotification('error', '请修正 Plugin JSON 格式错误')
+        if (this.formData.upstream_mode === 'upstream_id' && !this.formData.upstream_id.trim()) return this.actions.showNotification('error', '请选择要引用的上游')
+        if (this.formData.upstream_mode === 'nodes' && !this.validateInlineNodes()) return
+
         this.modalLoading = true
         try {
-            const payload = buildRoutePayload(this.formData)
-            // 编辑模式下，若 upstream_nodes 为空但原路由有 upstream 配置，则保留原始配置
-            if (this.isEditMode && !this.formData.upstream_nodes.some(n => n.host.trim() && String(n.port).trim()) && this.originalUpstream) {
-                payload.upstream = this.originalUpstream as typeof payload.upstream
-            }
+            const payload = buildRoutePayload(this.formData, this.originalUpstream)
             if (this.isEditMode) {
                 await api.apisixUpdateRoute(this.editingRouteId, payload)
                 this.actions.showNotification('success', '路由更新成功')
@@ -296,111 +463,336 @@ export default toNative(RouteEditModal)
 
 <template>
   <BaseModal v-model="isOpen" :title="isEditMode ? '编辑路由' : '创建路由'" :loading="modalLoading">
-    <div class="space-y-4 p-1">
-      <div class="grid grid-cols-2 gap-3">
-        <div><label class="block text-sm font-medium text-slate-700 mb-2">路由名称 <span class="text-red-500">*</span></label><input v-model="formData.name" type="text" class="input" placeholder="路由名称" /></div>
-        <div><label class="block text-sm font-medium text-slate-700 mb-2">优先级</label><input v-model.number="formData.priority" type="number" class="input" placeholder="0" /></div>
-      </div>
-      <div><label class="block text-sm font-medium text-slate-700 mb-2">描述</label><textarea v-model="formData.desc" rows="2" class="input" placeholder="路由描述"></textarea></div>
-      <div><label class="block text-sm font-medium text-slate-700 mb-2">URI（每行一个）<span class="text-red-500">*</span></label><textarea v-model="formData.uris" rows="3" class="input font-mono text-sm" placeholder="/api/v1/*&#10;/api/v2/*"></textarea></div>
-      <div><label class="block text-sm font-medium text-slate-700 mb-2">Host（每行一个，留空匹配所有）</label><textarea v-model="formData.hosts" rows="2" class="input font-mono text-sm" placeholder="example.com"></textarea></div>
-      <div>
-        <div class="flex items-center justify-between mb-2">
-          <label class="text-sm font-medium text-slate-700">上游节点</label>
-          <button @click="addUpstreamNode()" type="button" class="btn-icon text-indigo-600 hover:bg-indigo-50" title="添加节点"><i class="fas fa-plus text-xs"></i></button>
+    <div class="space-y-5 p-1">
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">路由名称</label>
+          <input v-model="formData.name" type="text" class="input" placeholder="例如：成员服务入口" />
+          <p class="text-xs text-slate-400 mt-1">用于在路由列表中识别当前规则。</p>
         </div>
-        <div class="rounded-lg border border-slate-200 overflow-hidden">
-          <table class="w-full text-sm">
-            <thead>
-              <tr class="bg-slate-50 border-b border-slate-200">
-                <th class="px-3 py-2 text-left text-xs font-semibold text-slate-600 w-1/2">主机</th>
-                <th class="px-3 py-2 text-left text-xs font-semibold text-slate-600 w-[30%]">端口</th>
-                <th class="px-3 py-2 text-left text-xs font-semibold text-slate-600 w-[20%]">权重</th>
-                <th v-if="formData.upstream_nodes.length > 1" class="px-3 py-2 w-8"></th>
-              </tr>
-            </thead>
-            <tbody class="divide-y divide-slate-100">
-              <tr v-for="(node, index) in formData.upstream_nodes" :key="index">
-                <td class="px-3 py-2"><HostSelect v-model="node.host" :containers="containers" placeholder="127.0.0.1 或 容器名" /></td>
-                <td class="px-3 py-2"><PortSelect v-model="node.port" :ports="getContainerPortsForNode(index)" placeholder="80" /></td>
-                <td class="px-3 py-2"><input v-model.number="node.weight" type="number" class="input" placeholder="1" min="0" /></td>
-                <td v-if="formData.upstream_nodes.length > 1" class="px-1 py-2 text-center">
-                  <button @click="removeUpstreamNode(index)" type="button" class="btn-icon text-red-400 hover:text-red-600 hover:bg-red-50" title="移除"><i class="fas fa-xmark text-xs"></i></button>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-        <div class="mt-3">
-          <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">负载均衡策略</label>
-          <select v-model="formData.upstream_type" class="input">
-            <option value="roundrobin">roundrobin（轮询）</option>
-            <option value="chash">chash（一致性哈希）</option>
-            <option value="ewma">ewma（加权移动平均）</option>
-            <option value="least_conn">least_conn（最少连接）</option>
-          </select>
+        <div>
+          <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">优先级</label>
+          <input v-model.number="formData.priority" type="number" min="0" class="input" placeholder="0" />
+          <p class="text-xs text-slate-400 mt-1">数值越大优先级越高，命中冲突时优先匹配。</p>
         </div>
       </div>
+
       <div>
-        <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">超时配置（秒）</label>
+        <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">描述</label>
+        <textarea v-model="formData.desc" rows="2" class="input" placeholder="补充路由用途、环境或业务说明"></textarea>
+      </div>
+
+      <div>
+        <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">超时配置（秒）</label>
         <div class="grid grid-cols-3 gap-3">
           <div><input v-model.number="formData.timeout_connect" type="number" class="input" placeholder="连接超时" min="0" /><p class="text-xs text-slate-400 mt-1">connect</p></div>
           <div><input v-model.number="formData.timeout_send" type="number" class="input" placeholder="发送超时" min="0" /><p class="text-xs text-slate-400 mt-1">send</p></div>
           <div><input v-model.number="formData.timeout_read" type="number" class="input" placeholder="读取超时" min="0" /><p class="text-xs text-slate-400 mt-1">read</p></div>
         </div>
       </div>
-      <div class="grid grid-cols-2 gap-3">
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div>
-          <label class="block text-sm font-medium text-slate-700 mb-2">WebSocket</label>
+          <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">URI（每行一个）</label>
+          <textarea v-model="formData.uris" rows="4" class="input font-mono text-sm" placeholder="/api/v1/*&#10;/api/v2/*"></textarea>
+          <p class="text-xs text-slate-400 mt-1">支持单条或多条 URI 规则。</p>
+        </div>
+        <div>
+          <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">Host（每行一个，留空匹配所有）</label>
+          <textarea v-model="formData.hosts" rows="4" class="input font-mono text-sm" placeholder="example.com&#10;api.example.com"></textarea>
+          <p class="text-xs text-slate-400 mt-1">可选，多 Host 时一行一个。</p>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">WebSocket</label>
           <select v-model="formData.enable_websocket" class="input">
             <option :value="false">关闭</option>
             <option :value="true">开启</option>
           </select>
         </div>
         <div>
-          <label class="block text-sm font-medium text-slate-700 mb-2">路由状态</label>
+          <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">路由状态</label>
           <select v-model="formData.status" class="input">
             <option :value="1">启用</option>
             <option :value="0">禁用</option>
           </select>
         </div>
       </div>
-      <div><label class="block text-sm font-medium text-slate-700 mb-2">复用插件配置</label>
-        <select v-model="formData.plugin_config_id" class="input"><option value="">不使用</option><option v-for="pc in pluginConfigs" :key="pc.id" :value="pc.id">{{ pc.desc || pc.id }}</option></select>
+
+      <div class="rounded-2xl border border-slate-200 bg-gradient-to-br from-slate-50 via-white to-indigo-50/50 p-4 md:p-5 shadow-sm">
+        <div class="flex items-start justify-between gap-3 mb-4">
+          <div>
+            <h3 class="text-sm font-semibold text-slate-800">上游转发策略</h3>
+            <p class="text-xs text-slate-500 mt-1">支持在同一个路由下配置多个上游节点，也可以直接引用已有上游。</p>
+          </div>
+
+        </div>
+
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-3 mb-4">
+          <button
+            v-for="item in upstreamModeCards"
+            :key="item.value"
+            type="button"
+            @click="setUpstreamMode(item.value as ApisixRouteUpstreamMode)"
+            :class="[
+              'text-left rounded-2xl border p-4 transition-colors duration-200 shadow-sm',
+              formData.upstream_mode === item.value
+                ? item.tone === 'indigo'
+                  ? 'border-indigo-300 bg-indigo-50 text-indigo-700 shadow-indigo-100'
+                  : item.tone === 'emerald'
+                    ? 'border-emerald-300 bg-emerald-50 text-emerald-700 shadow-emerald-100'
+                    : 'border-slate-300 bg-slate-100 text-slate-700'
+                : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300'
+            ]"
+          >
+            <div class="flex items-center justify-between gap-3 mb-2">
+              <div class="w-10 h-10 rounded-xl flex items-center justify-center"
+                :class="[
+                  formData.upstream_mode === item.value
+                    ? item.tone === 'indigo'
+                      ? 'bg-indigo-100'
+                      : item.tone === 'emerald'
+                        ? 'bg-emerald-100'
+                        : 'bg-slate-200'
+                    : 'bg-slate-100'
+                ]"
+              >
+                <i class="fas text-sm" :class="item.icon"></i>
+              </div>
+              <i v-if="formData.upstream_mode === item.value" class="fas fa-circle-check text-base"></i>
+            </div>
+            <div class="text-sm font-semibold">{{ item.title }}</div>
+            <div class="text-xs mt-1 opacity-80 leading-5">{{ item.desc }}</div>
+          </button>
+        </div>
+
+        <div v-if="formData.upstream_mode === 'nodes'" class="space-y-4">
+          <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-3 rounded-2xl bg-white border border-slate-200 p-4 shadow-sm">
+            <div class="grid grid-cols-2 md:grid-cols-4 gap-3 flex-1">
+              <div class="rounded-xl bg-slate-50 border border-slate-200 px-3 py-2">
+                <div class="text-[11px] uppercase tracking-wider text-slate-400 font-semibold">节点行数</div>
+                <div class="text-lg font-semibold text-slate-800 mt-1">{{ formData.upstream_nodes.length }}</div>
+              </div>
+              <div class="rounded-xl bg-slate-50 border border-slate-200 px-3 py-2">
+                <div class="text-[11px] uppercase tracking-wider text-slate-400 font-semibold">有效节点</div>
+                <div class="text-lg font-semibold text-indigo-600 mt-1">{{ selectedInlineNodeCount }}</div>
+              </div>
+              <div class="col-span-2 md:col-span-2 rounded-xl bg-slate-50 border border-slate-200 px-3 py-2">
+                <div class="text-[11px] uppercase tracking-wider text-slate-400 font-semibold">负载均衡策略</div>
+                <div class="text-sm font-semibold text-slate-800 mt-1">{{ selectedUpstreamTypeOption.label }}</div>
+                <div class="text-xs text-slate-400 mt-1">{{ selectedUpstreamTypeOption.desc }}</div>
+              </div>
+            </div>
+            <button type="button" @click="addUpstreamNode()" class="inline-flex items-center justify-center gap-2 px-4 py-2 rounded-xl bg-indigo-500 hover:bg-indigo-600 text-white text-sm font-medium transition-colors shadow-sm">
+              <i class="fas fa-plus"></i>
+              添加上游节点
+            </button>
+          </div>
+
+          <div class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+            <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">负载均衡策略</label>
+            <select v-model="formData.upstream_type" class="input">
+              <option v-for="option in upstreamTypeOptions" :key="option.value" :value="option.value">
+                {{ option.label }}
+              </option>
+            </select>
+            <p class="text-xs text-slate-400 mt-1">{{ selectedUpstreamTypeOption.desc }}</p>
+          </div>
+
+          <div v-if="formData.upstream_type === 'chash'" class="rounded-2xl border border-violet-200 bg-violet-50/40 p-4 shadow-sm space-y-3">
+            <div class="flex items-center gap-2 mb-1">
+              <i class="fas fa-fingerprint text-violet-500 text-sm"></i>
+              <span class="text-sm font-semibold text-violet-800">一致性哈希参数</span>
+            </div>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+              <div>
+                <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">哈希依据（hash_on）</label>
+                <select v-model="formData.upstream_hash_on" class="input">
+                  <option v-for="o in hashOnOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
+                </select>
+                <p class="text-xs text-slate-400 mt-1">决定用什么来计算哈希值</p>
+              </div>
+              <div>
+                <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">哈希键（key）</label>
+                <input v-model="formData.upstream_key" type="text" class="input" :placeholder="selectedHashOnOption.keyPlaceholder" />
+                <p class="text-xs text-slate-400 mt-1">{{ selectedHashOnOption.keyHint }}</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="space-y-3">
+            <div
+              v-for="(node, index) in formData.upstream_nodes"
+              :key="`node-${index}`"
+              class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm"
+            >
+              <div class="flex items-center justify-between gap-3 mb-4">
+                <div class="flex items-center gap-3 min-w-0">
+                  <div class="w-9 h-9 rounded-xl bg-indigo-100 text-indigo-700 flex items-center justify-center font-semibold text-sm">{{ index + 1 }}</div>
+                  <div>
+                    <div class="text-sm font-semibold text-slate-800">上游节点 {{ index + 1 }}</div>
+                    <div class="text-xs text-slate-400">支持容器选择或直接手动输入主机与端口</div>
+                  </div>
+                </div>
+                <button type="button" @click="removeUpstreamNode(index)" class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-red-50 text-red-600 hover:bg-red-100 text-xs font-medium transition-colors">
+                  <i class="fas fa-trash"></i>
+                  删除
+                </button>
+              </div>
+
+              <div class="grid grid-cols-1 md:grid-cols-12 gap-4 items-start">
+                <div class="md:col-span-5">
+                  <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">上游主机</label>
+                  <HostSelect
+                    :model-value="node.host"
+                    :containers="containers"
+                    placeholder="127.0.0.1 或 容器名"
+                    @update:modelValue="updateUpstreamNodeHost(index, $event)"
+                  />
+                </div>
+                <div class="md:col-span-4">
+                  <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">上游端口</label>
+                  <PortSelect
+                    :model-value="node.port"
+                    :ports="getPortsByHost(node.host)"
+                    placeholder="8080"
+                    @update:modelValue="updateUpstreamNodePort(index, $event)"
+                  />
+                </div>
+                <div class="md:col-span-3">
+                  <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">节点权重</label>
+                  <input v-model.number="node.weight" type="number" min="0" class="input" placeholder="1" />
+                  <p class="text-xs text-slate-400 mt-1">当前策略 {{ formData.upstream_type }} 下的节点权重。</p>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div v-if="routeValidationMessage" class="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-700">
+            {{ routeValidationMessage }}
+          </div>
+        </div>
+
+        <div v-else-if="formData.upstream_mode === 'upstream_id'" class="rounded-2xl border border-emerald-200 bg-white p-4 shadow-sm space-y-3">
+          <div>
+            <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">选择已有上游</label>
+            <select v-model="formData.upstream_id" class="input">
+              <option value="">请选择已有上游</option>
+              <option v-for="upstream in upstreams" :key="upstream.id" :value="upstream.id">
+                {{ upstream.name || upstream.id }}（{{ upstream.type || 'roundrobin' }}）
+              </option>
+            </select>
+            <p class="text-xs text-slate-400 mt-1">适用于复用已在 APISIX 中维护的上游对象。</p>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+            <div class="rounded-xl bg-emerald-50 border border-emerald-100 px-3 py-3 text-xs text-emerald-700">
+              <div class="font-semibold mb-1">为什么用引用模式</div>
+              <div>当多个路由共享同一组上游配置时，只需要维护一个上游对象。</div>
+            </div>
+            <div class="rounded-xl bg-slate-50 border border-slate-200 px-3 py-3 text-xs text-slate-600">
+              <div class="font-semibold mb-1">注意</div>
+              <div>切换为引用模式后，本路由将不再提交内联节点列表。</div>
+            </div>
+          </div>
+          <div v-if="routeValidationMessage" class="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-700">
+            {{ routeValidationMessage }}
+          </div>
+        </div>
+
+        <div v-else class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm space-y-3">
+          <div>
+            <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">暂不配置上游</label>
+            <p class="text-sm text-slate-600 leading-6">当前保存只会提交路由匹配规则、状态和插件配置，不会附带内联节点，也不会引用已有上游。</p>
+          </div>
+          <div class="rounded-xl bg-slate-50 border border-slate-200 px-3 py-3 text-xs text-slate-600">
+            <div class="font-semibold mb-1">适用场景</div>
+            <div>先创建占位路由，后续再由手工或其他流程补充上游配置。</div>
+          </div>
+        </div>
+
       </div>
+
       <div>
-        <div class="flex items-center justify-between mb-1">
-          <label class="text-sm font-medium text-slate-700">独立插件配置</label>
-          <div class="flex items-center gap-1">
-            <button @click="showPluginPanel = !showPluginPanel; showImportPanel = false" class="px-2 py-0.5 text-xs rounded bg-indigo-50 text-indigo-600 hover:bg-indigo-100 transition-colors"><i class="fas fa-puzzle-piece mr-1"></i>添加插件</button>
-            <button @click="showImportPanel = !showImportPanel; showPluginPanel = false" class="px-2 py-0.5 text-xs rounded bg-slate-50 text-slate-600 hover:bg-slate-50 transition-colors"><i class="fas fa-file-import mr-1"></i>从路由导入</button>
+        <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">复用插件配置</label>
+        <select v-model="formData.plugin_config_id" class="input">
+          <option value="">不使用</option>
+          <option v-for="pc in pluginConfigs" :key="pc.id" :value="pc.id">{{ pc.desc || pc.id }}</option>
+        </select>
+      </div>
+
+      <div class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+        <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-3 mb-3">
+          <div>
+            <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">独立插件配置</label>
+            <p class="text-xs text-slate-400">可直接编辑 JSON，也支持从现有路由导入。</p>
+          </div>
+          <div class="flex items-center gap-2">
+            <button @click="showPluginPanel = !showPluginPanel; showImportPanel = false" class="px-3 py-1.5 text-xs rounded-lg bg-indigo-50 text-indigo-600 hover:bg-indigo-100 transition-colors border border-indigo-100"><i class="fas fa-puzzle-piece mr-1"></i>添加插件</button>
+            <button @click="showImportPanel = !showImportPanel; showPluginPanel = false" class="px-3 py-1.5 text-xs rounded-lg bg-slate-50 text-slate-600 hover:bg-slate-100 transition-colors border border-slate-200"><i class="fas fa-file-import mr-1"></i>从路由导入</button>
           </div>
         </div>
-        <div v-if="showPluginPanel" class="mb-2 p-3 bg-slate-50 rounded-lg border border-slate-200">
-          <div class="mb-2"><input v-model="pluginSearchKeyword" type="text" placeholder="搜索插件..." class="input text-xs" /></div>
-          <div class="max-h-40 overflow-y-auto grid grid-cols-3 gap-1">
-            <button v-for="name in filteredAvailablePlugins" :key="name" @click="addPresetPlugin(name)" :class="['px-2 py-1 text-xs rounded text-left truncate transition-colors', formData.plugins[name] !== undefined ? 'bg-indigo-100 text-indigo-700 cursor-default' : 'bg-white hover:bg-indigo-50 text-slate-700']" :disabled="formData.plugins[name] !== undefined">{{ name }}</button>
+
+        <div v-if="showPluginPanel" class="mb-3 p-3 bg-slate-50 rounded-xl border border-slate-200">
+          <div class="mb-2">
+            <input v-model="pluginSearchKeyword" type="text" placeholder="搜索插件..." class="input text-xs" />
+          </div>
+          <div class="max-h-40 overflow-y-auto grid grid-cols-1 md:grid-cols-3 gap-2">
+            <button
+              v-for="name in filteredAvailablePlugins"
+              :key="name"
+              @click="addPresetPlugin(name)"
+              :class="[
+                'px-3 py-2 text-xs rounded-xl text-left truncate transition-colors border',
+                formData.plugins[name] !== undefined
+                  ? 'bg-indigo-100 text-indigo-700 border-indigo-200 cursor-default'
+                  : 'bg-white hover:bg-indigo-50 text-slate-700 border-slate-200'
+              ]"
+              :disabled="formData.plugins[name] !== undefined"
+            >
+              {{ name }}
+            </button>
           </div>
         </div>
-        <div v-if="showImportPanel" class="mb-2 p-3 bg-slate-50 rounded-lg border border-slate-200">
-          <div class="mb-2"><select v-model="importRouteId" @change="onImportRouteChange" class="input text-xs"><option value="">选择来源路由...</option><option v-for="r in routes" :key="r.id" :value="r.id">{{ r.name || r.id }}</option></select></div>
+
+        <div v-if="showImportPanel" class="mb-3 p-3 bg-slate-50 rounded-xl border border-slate-200">
+          <div class="mb-2">
+            <select v-model="importRouteId" @change="onImportRouteChange" class="input text-xs">
+              <option value="">选择来源路由...</option>
+              <option v-for="r in routes" :key="r.id" :value="r.id">{{ r.name || r.id }}</option>
+            </select>
+          </div>
           <div v-if="importRoutePluginsLoading" class="text-xs text-slate-500 text-center py-2">加载中...</div>
           <div v-else-if="Object.keys(importRoutePlugins).length > 0">
-            <div class="max-h-32 overflow-y-auto space-y-1 mb-2"><label v-for="(_, name) in importRoutePlugins" :key="name" class="flex items-center gap-2 text-xs cursor-pointer"><input type="checkbox" :checked="selectedImportPlugins.has(name)" @change="toggleImportPlugin(name)" class="rounded border-slate-300 text-indigo-500 focus:ring-indigo-500" /><span>{{ name }}</span></label></div>
-            <button @click="importPluginsFromRoute" class="px-3 py-1 text-xs bg-indigo-500 text-white rounded hover:bg-indigo-600 transition-colors">导入选中插件</button>
+            <div class="max-h-32 overflow-y-auto space-y-1 mb-2">
+              <label v-for="(_, name) in importRoutePlugins" :key="name" class="flex items-center gap-2 text-xs cursor-pointer rounded-lg px-2 py-1 hover:bg-white">
+                <input type="checkbox" :checked="selectedImportPlugins.has(name)" @change="toggleImportPlugin(name)" class="rounded border-slate-300 text-indigo-500 focus:ring-indigo-500" />
+                <span>{{ name }}</span>
+              </label>
+            </div>
+            <button @click="importPluginsFromRoute" class="px-3 py-1.5 text-xs bg-indigo-500 text-white rounded-lg hover:bg-indigo-600 transition-colors">导入选中插件</button>
           </div>
         </div>
-        <div v-if="currentPluginNames.length > 0" class="flex flex-wrap gap-1 mb-2">
-          <span v-for="name in currentPluginNames" :key="name" class="inline-flex items-center gap-1 px-2 py-0.5 bg-indigo-50 text-indigo-700 rounded text-xs">{{ name }}<button @click="removePlugin(name)" class="hover:text-red-500 transition-colors"><i class="fas fa-xmark text-[10px]"></i></button></span>
+
+        <div v-if="currentPluginNames.length > 0" class="flex flex-wrap gap-1.5 mb-3">
+          <span v-for="name in currentPluginNames" :key="name" class="inline-flex items-center gap-1 px-2.5 py-1 bg-indigo-50 text-indigo-700 rounded-full text-xs border border-indigo-100">
+            {{ name }}
+            <button @click="removePlugin(name)" class="hover:text-red-500 transition-colors"><i class="fas fa-xmark text-[10px]"></i></button>
+          </span>
         </div>
+
         <textarea v-model="formData.pluginsJson" @blur="syncPluginsFromJson" rows="8" :class="['input font-mono text-sm', formData.pluginsJsonError ? 'border-red-300 bg-red-50' : '']" placeholder='{"key-auth": {}, "proxy-rewrite": {"uri": "/new-path"}}'></textarea>
         <p v-if="formData.pluginsJsonError" class="text-xs text-red-500 mt-1">{{ formData.pluginsJsonError }}</p>
       </div>
     </div>
+
     <template #footer>
       <div class="flex justify-end gap-2">
         <button @click="isOpen = false" class="px-4 py-2 text-sm font-medium text-slate-700 bg-white border border-slate-200 rounded-lg hover:bg-slate-50">取消</button>
-        <button @click="handleConfirm()" :disabled="modalLoading" class="px-4 py-2 text-sm font-medium text-white bg-indigo-500 rounded-lg hover:bg-indigo-600 disabled:opacity-50"><i v-if="modalLoading" class="fas fa-spinner fa-spin mr-1"></i>{{ isEditMode ? '保存' : '创建' }}</button>
+        <button @click="handleConfirm()" :disabled="modalLoading" class="px-4 py-2 text-sm font-medium text-white bg-indigo-500 rounded-lg hover:bg-indigo-600 disabled:opacity-50 shadow-sm">
+          <i v-if="modalLoading" class="fas fa-spinner fa-spin mr-1"></i>{{ isEditMode ? '保存' : '创建' }}
+        </button>
       </div>
     </template>
   </BaseModal>

--- a/webview/src/views/apisix/widget/route-edit-modal.vue
+++ b/webview/src/views/apisix/widget/route-edit-modal.vue
@@ -26,9 +26,63 @@ import {
 } from '@/helper/utils'
 
 import BaseModal from '@/component/modal.vue'
-
 import HostSelect from './host-select.vue'
 import PortSelect from './port-select.vue'
+
+// ─── 模块级静态常量 ───
+
+const UPSTREAM_MODE_CARDS: ApisixRouteUpstreamModeCard[] = [
+    { value: 'nodes', title: '内联多上游节点', desc: '一个路由直连多个节点，并为每个节点设置权重', icon: 'fa-circle-nodes', tone: 'indigo' },
+    { value: 'upstream_id', title: '引用已有上游', desc: '复用 APISIX 中已经创建好的上游对象', icon: 'fa-diagram-project', tone: 'emerald' },
+    { value: 'none', title: '空上游', desc: '暂不配置转发目标，先保存路由规则', icon: 'fa-ban', tone: 'slate' }
+]
+
+const UPSTREAM_TYPE_OPTIONS: Array<{ value: ApisixUpstreamType; label: string; desc: string }> = [
+    { value: 'roundrobin', label: 'roundrobin', desc: '按权重轮询分配请求' },
+    { value: 'least_conn', label: 'least_conn', desc: '优先选择当前连接数更少的节点' },
+    { value: 'ewma', label: 'ewma', desc: '根据历史延迟动态选择更快的节点' },
+    { value: 'chash', label: 'chash', desc: '一致性哈希，适合会话粘性场景' }
+]
+
+const HASH_ON_OPTIONS: Array<{ value: ApisixUpstreamHashOn; label: string; keyPlaceholder: string; keyHint: string }> = [
+    { value: 'vars', label: 'vars（Nginx 变量）', keyPlaceholder: 'remote_addr', keyHint: 'Nginx 变量名，不带 $ 前缀，如 remote_addr、uri' },
+    { value: 'header', label: 'header（请求头）', keyPlaceholder: 'X-User-Id', keyHint: '请求头名称，如 X-User-Id' },
+    { value: 'cookie', label: 'cookie', keyPlaceholder: 'session_id', keyHint: 'Cookie 名称（大小写敏感），如 session_id' },
+    { value: 'consumer', label: 'consumer（消费者）', keyPlaceholder: 'consumer_name', keyHint: '通常填 consumer_name，由 APISIX 自动注入' },
+    { value: 'vars_combinations', label: 'vars_combinations', keyPlaceholder: '$remote_addr$uri', keyHint: '多个 Nginx 变量组合，如 $remote_addr$uri' }
+]
+
+const TYPE_DEFAULTS: Record<string, string | number | boolean | unknown[] | Record<string, unknown>> = { string: '', integer: 0, number: 0, boolean: false, array: [], object: {} }
+
+const TONE_CARD_ACTIVE: Record<string, string> = {
+    indigo: 'border-indigo-300 bg-indigo-50 text-indigo-700',
+    emerald: 'border-emerald-300 bg-emerald-50 text-emerald-700',
+    slate: 'border-slate-300 bg-slate-100 text-slate-700'
+}
+const TONE_ICON_ACTIVE: Record<string, string> = { indigo: 'bg-indigo-100', emerald: 'bg-emerald-100', slate: 'bg-slate-200' }
+
+const defaultFormData = () => ({
+    name: '',
+    desc: '',
+    uris: '',
+    hosts: '',
+    status: 1,
+    priority: 0,
+    enable_websocket: false,
+    plugin_config_id: '',
+    plugins: {} as Record<string, unknown>,
+    pluginsJson: '{}',
+    pluginsJsonError: '',
+    upstream_mode: 'nodes' as ApisixRouteUpstreamMode,
+    upstream_type: 'roundrobin' as ApisixUpstreamType,
+    upstream_id: '',
+    upstream_nodes: [{ host: '', port: '', weight: 1 }] as ApisixRouteUpstreamFormNode[],
+    upstream_hash_on: 'vars' as ApisixUpstreamHashOn,
+    upstream_key: 'remote_addr',
+    timeout_connect: '' as string | number,
+    timeout_send: '' as string | number,
+    timeout_read: '' as string | number,
+})
 
 @Component({
     expose: ['show'],
@@ -58,114 +112,44 @@ class RouteEditModal extends Vue {
     availablePlugins: Record<string, { schema: Record<string, unknown> }> = {}
     routes: ApisixRoute[] = []
 
-    formData = {
-        name: '',
-        desc: '',
-        uris: '',
-        hosts: '',
-        status: 1,
-        priority: 0,
-        enable_websocket: false,
-        plugin_config_id: '',
-        plugins: {} as Record<string, unknown>,
-        pluginsJson: '{}',
-        pluginsJsonError: '',
-        upstream_mode: 'nodes' as ApisixRouteUpstreamMode,
-        upstream_type: 'roundrobin' as ApisixUpstreamType,
-        upstream_id: '',
-        upstream_nodes: [{ host: '', port: '', weight: 1 }] as ApisixRouteUpstreamFormNode[],
-        upstream_hash_on: 'vars' as ApisixUpstreamHashOn,
-        upstream_key: 'remote_addr',
-        timeout_connect: '' as string | number,
-        timeout_send: '' as string | number,
-        timeout_read: '' as string | number
-    }
+    formData = defaultFormData()
+
+    // 暴露常量给模板
+    readonly upstreamModeCards = UPSTREAM_MODE_CARDS
+    readonly upstreamTypeOptions = UPSTREAM_TYPE_OPTIONS
+    readonly hashOnOptions = HASH_ON_OPTIONS
 
     // ─── 计算属性 ───
-    get currentPluginNames() {
-        return Object.keys(this.formData.plugins || {})
-    }
+    get currentPluginNames() { return Object.keys(this.formData.plugins || {}) }
 
     get filteredAvailablePlugins() {
+        const kw = this.pluginSearchKeyword.toLowerCase()
         const all = Object.keys(this.availablePlugins)
-        if (!this.pluginSearchKeyword) return all
-        return all.filter(n => n.toLowerCase().includes(this.pluginSearchKeyword.toLowerCase()))
-    }
-
-    get selectedInlineNodeCount() {
-        return this.formData.upstream_nodes.filter(node => node.host.trim() && String(node.port).trim()).length
-    }
-
-    get upstreamModeCards(): ApisixRouteUpstreamModeCard[] {
-        return [
-            {
-                value: 'nodes',
-                title: '内联多上游节点',
-                desc: '一个路由直连多个节点，并为每个节点设置权重',
-                icon: 'fa-circle-nodes',
-                tone: 'indigo'
-            },
-            {
-                value: 'upstream_id',
-                title: '引用已有上游',
-                desc: '复用 APISIX 中已经创建好的上游对象',
-                icon: 'fa-diagram-project',
-                tone: 'emerald'
-            },
-            {
-                value: 'none',
-                title: '空上游',
-                desc: '暂不配置转发目标，先保存路由规则',
-                icon: 'fa-ban',
-                tone: 'slate'
-            },
-        ]
-    }
-
-    get upstreamTypeOptions(): Array<{ value: ApisixUpstreamType; label: string; desc: string }> {
-        return [
-            { value: 'roundrobin', label: 'roundrobin', desc: '按权重轮询分配请求' },
-            { value: 'least_conn', label: 'least_conn', desc: '优先选择当前连接数更少的节点' },
-            { value: 'ewma', label: 'ewma', desc: '根据历史延迟动态选择更快的节点' },
-            { value: 'chash', label: 'chash', desc: '一致性哈希，适合会话粘性场景' }
-        ]
-    }
-
-    get hashOnOptions(): Array<{ value: ApisixUpstreamHashOn; label: string; keyPlaceholder: string; keyHint: string }> {
-        return [
-            { value: 'vars',             label: 'vars（Nginx 变量）',    keyPlaceholder: 'remote_addr',  keyHint: 'Nginx 变量名，不带 $ 前缀，如 remote_addr、uri' },
-            { value: 'header',           label: 'header（请求头）',      keyPlaceholder: 'X-User-Id',    keyHint: '请求头名称，如 X-User-Id' },
-            { value: 'cookie',           label: 'cookie',               keyPlaceholder: 'session_id',   keyHint: 'Cookie 名称（大小写敏感），如 session_id' },
-            { value: 'consumer',         label: 'consumer（消费者）',    keyPlaceholder: 'consumer_name', keyHint: '通常填 consumer_name，由 APISIX 自动注入' },
-            { value: 'vars_combinations', label: 'vars_combinations',   keyPlaceholder: '$remote_addr$uri', keyHint: '多个 Nginx 变量组合，如 $remote_addr$uri' },
-        ]
-    }
-
-    get selectedHashOnOption() {
-        return this.hashOnOptions.find(o => o.value === this.formData.upstream_hash_on) || this.hashOnOptions[0]
+        return kw ? all.filter(n => n.toLowerCase().includes(kw)) : all
     }
 
     get selectedUpstreamTypeOption() {
-        return this.upstreamTypeOptions.find(option => option.value === this.formData.upstream_type) || this.upstreamTypeOptions[0]
+        return UPSTREAM_TYPE_OPTIONS.find(o => o.value === this.formData.upstream_type) ?? UPSTREAM_TYPE_OPTIONS[0]
+    }
+
+    get selectedHashOnOption() {
+        return HASH_ON_OPTIONS.find(o => o.value === this.formData.upstream_hash_on) ?? HASH_ON_OPTIONS[0]
     }
 
     get routeValidationMessage() {
-        if (this.formData.upstream_mode === 'upstream_id') {
-            return this.formData.upstream_id.trim() ? '' : '请选择要引用的上游对象'
-        }
-
-        if (this.formData.upstream_mode !== 'nodes') return ''
+        const mode = this.formData.upstream_mode
+        if (mode === 'upstream_id') return this.formData.upstream_id.trim() ? '' : '请选择要引用的上游对象'
+        if (mode !== 'nodes') return ''
 
         const rows = this.formData.upstream_nodes
-        const validRows = rows.filter(node => node.host.trim() && String(node.port).trim())
-        if (validRows.length === 0) return '请至少配置一个完整的上游节点'
+        if (!rows.some(n => n.host.trim() && String(n.port).trim())) return '请至少配置一个完整的上游节点'
 
-        for (const [index, node] of rows.entries()) {
+        for (const [i, node] of rows.entries()) {
             const hasHost = !!node.host.trim()
             const hasPort = !!String(node.port).trim()
-            if (hasHost !== hasPort) return `第 ${index + 1} 个上游节点的主机和端口需要同时填写`
-            if (hasPort && !/^\d+$/.test(String(node.port).trim())) return `第 ${index + 1} 个上游节点端口必须为数字`
-            if ((hasHost || hasPort) && Number(node.weight) < 0) return `第 ${index + 1} 个上游节点权重不能为负数`
+            if (hasHost !== hasPort) return `第 ${i + 1} 个上游节点的主机和端口需要同时填写`
+            if (hasPort && !/^\d+$/.test(String(node.port).trim())) return `第 ${i + 1} 个上游节点端口必须为数字`
+            if ((hasHost || hasPort) && Number(node.weight) < 0) return `第 ${i + 1} 个上游节点权重不能为负数`
         }
 
         if (this.formData.upstream_type === 'chash' && !this.formData.upstream_key?.trim()) {
@@ -175,30 +159,21 @@ class RouteEditModal extends Vue {
         return ''
     }
 
+    // ─── 模式卡片样式 ───
+    modeCardClass(item: ApisixRouteUpstreamModeCard) {
+        const base = 'text-left rounded-xl border p-4 transition-colors'
+        const active = this.formData.upstream_mode === item.value
+        return `${base} ${active ? TONE_CARD_ACTIVE[item.tone] : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300'}`
+    }
+
+    modeCardIconClass(item: ApisixRouteUpstreamModeCard) {
+        const active = this.formData.upstream_mode === item.value
+        return `w-10 h-10 rounded-xl flex items-center justify-center ${active ? TONE_ICON_ACTIVE[item.tone] : 'bg-slate-100'}`
+    }
+
     // ─── 方法 ───
     resetForm() {
-        Object.assign(this.formData, {
-            name: '',
-            desc: '',
-            uris: '',
-            hosts: '',
-            status: 1,
-            priority: 0,
-            enable_websocket: false,
-            plugin_config_id: '',
-            plugins: {},
-            pluginsJson: '{}',
-            pluginsJsonError: '',
-            upstream_mode: 'nodes',
-            upstream_type: 'roundrobin',
-            upstream_id: '',
-            upstream_nodes: [{ host: '', port: '', weight: 1 }],
-            upstream_hash_on: 'vars',
-            upstream_key: 'remote_addr',
-            timeout_connect: '',
-            timeout_send: '',
-            timeout_read: ''
-        })
+        Object.assign(this.formData, defaultFormData())
         this.editingRouteId = ''
         this.originalUpstream = null
         this.showPluginPanel = false
@@ -209,59 +184,40 @@ class RouteEditModal extends Vue {
         this.pluginSearchKeyword = ''
     }
 
-    createUpstreamNode(node?: Partial<ApisixRouteUpstreamFormNode>): ApisixRouteUpstreamFormNode {
-        return {
-            host: node?.host || '',
-            port: String(node?.port || ''),
-            weight: Number(node?.weight) >= 0 ? Number(node?.weight) : 1
-        }
+    createUpstreamNode(): ApisixRouteUpstreamFormNode {
+        return { host: '', port: '', weight: 1 }
     }
 
-    addUpstreamNode(node?: Partial<ApisixRouteUpstreamFormNode>) {
-        this.formData.upstream_nodes = [...this.formData.upstream_nodes, this.createUpstreamNode(node)]
+    // ─── 上游节点管理 ───
+    addUpstreamNode() {
+        this.formData.upstream_nodes = [...this.formData.upstream_nodes, this.createUpstreamNode()]
     }
 
     removeUpstreamNode(index: number) {
-        const next = this.formData.upstream_nodes.filter((_, idx) => idx !== index)
+        const next = this.formData.upstream_nodes.filter((_, i) => i !== index)
         this.formData.upstream_nodes = next.length > 0 ? next : [this.createUpstreamNode()]
     }
 
     setUpstreamMode(mode: ApisixRouteUpstreamMode) {
         this.formData.upstream_mode = mode
-        if (mode === 'nodes' && this.formData.upstream_nodes.length === 0) {
+        if (mode === 'nodes' && !this.formData.upstream_nodes.length) {
             this.formData.upstream_nodes = [this.createUpstreamNode()]
         }
     }
 
-    getContainerByHost(host: string) {
-        const normalized = host.trim()
-        return normalized ? this.containers.find(c => c.name === normalized) : undefined
-    }
-
     getPortsByHost(host: string): string[] {
-        return this.getContainerByHost(host)?.ports || []
+        return this.containers.find(c => c.name === host.trim())?.ports || []
     }
 
-    extractDefaultPort(ports: string[]) {
-        const first = ports[0] || ''
-        return first.split('/')[0].split(':').pop() || ''
-    }
-
-    updateUpstreamNodeHost(index: number, host: string) {
+    updateUpstreamNode(index: number, field: 'host' | 'port', value: string) {
         const next = [...this.formData.upstream_nodes]
-        const current = next[index]
-        if (!current) return
-        current.host = host
-        const defaultPort = this.extractDefaultPort(this.getPortsByHost(host))
-        if (defaultPort) current.port = defaultPort
-        this.formData.upstream_nodes = next
-    }
-
-    updateUpstreamNodePort(index: number, port: string) {
-        const next = [...this.formData.upstream_nodes]
-        const current = next[index]
-        if (!current) return
-        current.port = port
+        const node = next[index]
+        if (!node) return
+        node[field] = value
+        if (field === 'host' && value.trim()) {
+            const port = (this.getPortsByHost(value)[0] || '').split('/')[0].split(':').pop() || ''
+            if (port) node.port = port
+        }
         this.formData.upstream_nodes = next
     }
 
@@ -283,15 +239,14 @@ class RouteEditModal extends Vue {
 
     async show(route: ApisixRoute | null, allRoutes: ApisixRoute[]) {
         await this.loadResources(allRoutes)
-        if (route && route.id) {
-            const routeID = route.id
+        if (route?.id) {
             this.isEditMode = true
             this.resetForm()
-            this.editingRouteId = routeID
+            this.editingRouteId = route.id
             this.modalLoading = true
             this.isOpen = true
             try {
-                const r = (await api.apisixGetRoute(routeID)).payload
+                const r = (await api.apisixGetRoute(route.id)).payload
                 if (!r) {
                     this.actions.showNotification('error', '加载路由详情失败')
                     this.isOpen = false
@@ -320,7 +275,7 @@ class RouteEditModal extends Vue {
                     upstream_key: (r.upstream?.key as string) || 'remote_addr',
                     timeout_connect: r.timeout?.connect ?? '',
                     timeout_send: r.timeout?.send ?? '',
-                    timeout_read: r.timeout?.read ?? ''
+                    timeout_read: r.timeout?.read ?? '',
                 })
             } catch {
                 this.actions.showNotification('error', '加载路由详情失败')
@@ -329,7 +284,6 @@ class RouteEditModal extends Vue {
             this.modalLoading = false
             return
         }
-
         this.isEditMode = false
         this.resetForm()
         this.isOpen = true
@@ -351,15 +305,6 @@ class RouteEditModal extends Vue {
         this.formData.pluginsJson = JSON.stringify(p, null, 2)
     }
 
-    readonly TYPE_DEFAULTS: Record<string, string | number | boolean | unknown[] | Record<string, unknown>> = {
-        string: '',
-        integer: 0,
-        number: 0,
-        boolean: false,
-        array: [],
-        object: {}
-    }
-
     buildPluginDefault(schema: { properties?: Record<string, { type: string; default?: unknown }>; required?: string[] }) {
         if (!schema?.properties) return {}
         const required = new Set(schema.required || [])
@@ -367,7 +312,7 @@ class RouteEditModal extends Vue {
         for (const [key, def] of Object.entries(schema.properties)) {
             if (key === 'disable') continue
             if (required.has(key) || def.default !== undefined) {
-                result[key] = def.default !== undefined ? def.default : (this.TYPE_DEFAULTS[def.type] ?? null)
+                result[key] = def.default !== undefined ? def.default : (TYPE_DEFAULTS[def.type] ?? null)
             }
         }
         return result
@@ -377,8 +322,7 @@ class RouteEditModal extends Vue {
         if (this.formData.plugins[name] !== undefined) {
             return this.actions.showNotification('warning', `插件 ${name} 已存在`)
         }
-        const schema = this.availablePlugins[name]?.schema
-        const p = { ...this.formData.plugins, [name]: this.buildPluginDefault(schema) }
+        const p = { ...this.formData.plugins, [name]: this.buildPluginDefault(this.availablePlugins[name]?.schema) }
         this.formData.plugins = p
         this.formData.pluginsJson = JSON.stringify(p, null, 2)
         this.showPluginPanel = false
@@ -408,11 +352,12 @@ class RouteEditModal extends Vue {
 
     importPluginsFromRoute() {
         if (!this.importRouteId) return this.actions.showNotification('warning', '请先选择要导入的路由')
-        if (this.selectedImportPlugins.size === 0) return this.actions.showNotification('warning', '请至少勾选一个插件')
-        const toImport: Record<string, unknown> = {}
-        for (const name of this.selectedImportPlugins) {
-            if (this.importRoutePlugins[name] !== undefined) toImport[name] = this.importRoutePlugins[name]
-        }
+        if (!this.selectedImportPlugins.size) return this.actions.showNotification('warning', '请至少勾选一个插件')
+        const toImport = Object.fromEntries(
+            [...this.selectedImportPlugins]
+                .filter(n => this.importRoutePlugins[n] !== undefined)
+                .map(n => [n, this.importRoutePlugins[n]])
+        )
         const merged = { ...this.formData.plugins, ...toImport }
         this.formData.plugins = merged
         this.formData.pluginsJson = JSON.stringify(merged, null, 2)
@@ -423,20 +368,11 @@ class RouteEditModal extends Vue {
         this.actions.showNotification('success', `已导入 ${Object.keys(toImport).length} 个插件`)
     }
 
-    validateInlineNodes() {
-        if (this.routeValidationMessage) {
-            this.actions.showNotification('error', this.routeValidationMessage)
-            return false
-        }
-        return true
-    }
-
     async handleConfirm() {
         if (!this.formData.name.trim()) return this.actions.showNotification('error', '路由名称不能为空')
-        if (!this.formData.uris.split('\n').map((s: string) => s.trim()).filter(Boolean).length) return this.actions.showNotification('error', 'URI 不能为空')
+        if (!this.formData.uris.split('\n').map(s => s.trim()).filter(Boolean).length) return this.actions.showNotification('error', 'URI 不能为空')
         if (this.formData.pluginsJsonError) return this.actions.showNotification('error', '请修正 Plugin JSON 格式错误')
-        if (this.formData.upstream_mode === 'upstream_id' && !this.formData.upstream_id.trim()) return this.actions.showNotification('error', '请选择要引用的上游')
-        if (this.formData.upstream_mode === 'nodes' && !this.validateInlineNodes()) return
+        if (this.routeValidationMessage) return this.actions.showNotification('error', this.routeValidationMessage)
 
         this.modalLoading = true
         try {
@@ -463,266 +399,107 @@ export default toNative(RouteEditModal)
 
 <template>
   <BaseModal v-model="isOpen" :title="isEditMode ? '编辑路由' : '创建路由'" :loading="modalLoading">
-    <div class="space-y-5 p-1">
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div>
-          <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">路由名称</label>
-          <input v-model="formData.name" type="text" class="input" placeholder="例如：成员服务入口" />
-          <p class="text-xs text-slate-400 mt-1">用于在路由列表中识别当前规则。</p>
-        </div>
-        <div>
-          <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">优先级</label>
-          <input v-model.number="formData.priority" type="number" min="0" class="input" placeholder="0" />
-          <p class="text-xs text-slate-400 mt-1">数值越大优先级越高，命中冲突时优先匹配。</p>
-        </div>
+    <div class="space-y-4 p-1">
+      <div class="grid grid-cols-2 gap-3">
+        <div><label class="block text-sm font-medium text-slate-700 mb-2">路由名称 <span class="text-red-500">*</span></label><input v-model="formData.name" type="text" class="input" placeholder="路由名称" /></div>
+        <div><label class="block text-sm font-medium text-slate-700 mb-2">优先级</label><input v-model.number="formData.priority" type="number" class="input" placeholder="0" min="0" /></div>
       </div>
+      <div><label class="block text-sm font-medium text-slate-700 mb-2">描述</label><textarea v-model="formData.desc" rows="2" class="input" placeholder="路由描述"></textarea></div>
+      <div><label class="block text-sm font-medium text-slate-700 mb-2">URI（每行一个）<span class="text-red-500">*</span></label><textarea v-model="formData.uris" rows="3" class="input font-mono text-sm" placeholder="/api/v1/*&#10;/api/v2/*"></textarea></div>
+      <div><label class="block text-sm font-medium text-slate-700 mb-2">Host（每行一个，留空匹配所有）</label><textarea v-model="formData.hosts" rows="2" class="input font-mono text-sm" placeholder="example.com"></textarea></div>
 
-      <div>
-        <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">描述</label>
-        <textarea v-model="formData.desc" rows="2" class="input" placeholder="补充路由用途、环境或业务说明"></textarea>
-      </div>
-
-      <div>
-        <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">超时配置（秒）</label>
-        <div class="grid grid-cols-3 gap-3">
-          <div><input v-model.number="formData.timeout_connect" type="number" class="input" placeholder="连接超时" min="0" /><p class="text-xs text-slate-400 mt-1">connect</p></div>
-          <div><input v-model.number="formData.timeout_send" type="number" class="input" placeholder="发送超时" min="0" /><p class="text-xs text-slate-400 mt-1">send</p></div>
-          <div><input v-model.number="formData.timeout_read" type="number" class="input" placeholder="读取超时" min="0" /><p class="text-xs text-slate-400 mt-1">read</p></div>
-        </div>
-      </div>
-
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div>
-          <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">URI（每行一个）</label>
-          <textarea v-model="formData.uris" rows="4" class="input font-mono text-sm" placeholder="/api/v1/*&#10;/api/v2/*"></textarea>
-          <p class="text-xs text-slate-400 mt-1">支持单条或多条 URI 规则。</p>
-        </div>
-        <div>
-          <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">Host（每行一个，留空匹配所有）</label>
-          <textarea v-model="formData.hosts" rows="4" class="input font-mono text-sm" placeholder="example.com&#10;api.example.com"></textarea>
-          <p class="text-xs text-slate-400 mt-1">可选，多 Host 时一行一个。</p>
-        </div>
-      </div>
-
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div>
-          <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">WebSocket</label>
-          <select v-model="formData.enable_websocket" class="input">
-            <option :value="false">关闭</option>
-            <option :value="true">开启</option>
-          </select>
-        </div>
-        <div>
-          <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">路由状态</label>
-          <select v-model="formData.status" class="input">
-            <option :value="1">启用</option>
-            <option :value="0">禁用</option>
-          </select>
-        </div>
-      </div>
-
-      <div class="rounded-2xl border border-slate-200 bg-gradient-to-br from-slate-50 via-white to-indigo-50/50 p-4 md:p-5 shadow-sm">
-        <div class="flex items-start justify-between gap-3 mb-4">
+      <div class="border border-slate-200 rounded-xl p-4">
+        <div class="flex items-center justify-between mb-3">
           <div>
-            <h3 class="text-sm font-semibold text-slate-800">上游转发策略</h3>
-            <p class="text-xs text-slate-500 mt-1">支持在同一个路由下配置多个上游节点，也可以直接引用已有上游。</p>
+            <label class="block text-sm font-medium text-slate-700">上游配置</label>
+            <p class="text-xs text-slate-400 mt-1">支持多节点、引用已有上游或暂不配置上游</p>
           </div>
-
         </div>
 
         <div class="grid grid-cols-1 md:grid-cols-3 gap-3 mb-4">
-          <button
-            v-for="item in upstreamModeCards"
-            :key="item.value"
-            type="button"
-            @click="setUpstreamMode(item.value as ApisixRouteUpstreamMode)"
-            :class="[
-              'text-left rounded-2xl border p-4 transition-colors duration-200 shadow-sm',
-              formData.upstream_mode === item.value
-                ? item.tone === 'indigo'
-                  ? 'border-indigo-300 bg-indigo-50 text-indigo-700 shadow-indigo-100'
-                  : item.tone === 'emerald'
-                    ? 'border-emerald-300 bg-emerald-50 text-emerald-700 shadow-emerald-100'
-                    : 'border-slate-300 bg-slate-100 text-slate-700'
-                : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300'
-            ]"
-          >
-            <div class="flex items-center justify-between gap-3 mb-2">
-              <div class="w-10 h-10 rounded-xl flex items-center justify-center"
-                :class="[
-                  formData.upstream_mode === item.value
-                    ? item.tone === 'indigo'
-                      ? 'bg-indigo-100'
-                      : item.tone === 'emerald'
-                        ? 'bg-emerald-100'
-                        : 'bg-slate-200'
-                    : 'bg-slate-100'
-                ]"
-              >
-                <i class="fas text-sm" :class="item.icon"></i>
-              </div>
-              <i v-if="formData.upstream_mode === item.value" class="fas fa-circle-check text-base"></i>
+          <button v-for="item in upstreamModeCards" :key="item.value" type="button" :class="modeCardClass(item)" @click="setUpstreamMode(item.value)">
+            <div class="flex items-center gap-2 mb-1">
+              <div :class="modeCardIconClass(item)"><i class="fas text-sm" :class="item.icon"></i></div>
+              <span class="text-sm font-semibold">{{ item.title }}</span>
             </div>
-            <div class="text-sm font-semibold">{{ item.title }}</div>
-            <div class="text-xs mt-1 opacity-80 leading-5">{{ item.desc }}</div>
+            <div class="text-xs opacity-80 leading-5">{{ item.desc }}</div>
           </button>
         </div>
 
-        <div v-if="formData.upstream_mode === 'nodes'" class="space-y-4">
-          <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-3 rounded-2xl bg-white border border-slate-200 p-4 shadow-sm">
-            <div class="grid grid-cols-2 md:grid-cols-4 gap-3 flex-1">
-              <div class="rounded-xl bg-slate-50 border border-slate-200 px-3 py-2">
-                <div class="text-[11px] uppercase tracking-wider text-slate-400 font-semibold">节点行数</div>
-                <div class="text-lg font-semibold text-slate-800 mt-1">{{ formData.upstream_nodes.length }}</div>
-              </div>
-              <div class="rounded-xl bg-slate-50 border border-slate-200 px-3 py-2">
-                <div class="text-[11px] uppercase tracking-wider text-slate-400 font-semibold">有效节点</div>
-                <div class="text-lg font-semibold text-indigo-600 mt-1">{{ selectedInlineNodeCount }}</div>
-              </div>
-              <div class="col-span-2 md:col-span-2 rounded-xl bg-slate-50 border border-slate-200 px-3 py-2">
-                <div class="text-[11px] uppercase tracking-wider text-slate-400 font-semibold">负载均衡策略</div>
-                <div class="text-sm font-semibold text-slate-800 mt-1">{{ selectedUpstreamTypeOption.label }}</div>
-                <div class="text-xs text-slate-400 mt-1">{{ selectedUpstreamTypeOption.desc }}</div>
-              </div>
+        <div v-if="formData.upstream_mode === 'nodes'" class="space-y-3">
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+            <div>
+              <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">负载均衡策略</label>
+              <select v-model="formData.upstream_type" class="input">
+                <option v-for="o in upstreamTypeOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
+              </select>
+              <p class="text-xs text-slate-400 mt-1">{{ selectedUpstreamTypeOption.desc }}</p>
             </div>
-            <button type="button" @click="addUpstreamNode()" class="inline-flex items-center justify-center gap-2 px-4 py-2 rounded-xl bg-indigo-500 hover:bg-indigo-600 text-white text-sm font-medium transition-colors shadow-sm">
-              <i class="fas fa-plus"></i>
-              添加上游节点
-            </button>
-          </div>
-
-          <div class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
-            <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">负载均衡策略</label>
-            <select v-model="formData.upstream_type" class="input">
-              <option v-for="option in upstreamTypeOptions" :key="option.value" :value="option.value">
-                {{ option.label }}
-              </option>
-            </select>
-            <p class="text-xs text-slate-400 mt-1">{{ selectedUpstreamTypeOption.desc }}</p>
-          </div>
-
-          <div v-if="formData.upstream_type === 'chash'" class="rounded-2xl border border-violet-200 bg-violet-50/40 p-4 shadow-sm space-y-3">
-            <div class="flex items-center gap-2 mb-1">
-              <i class="fas fa-fingerprint text-violet-500 text-sm"></i>
-              <span class="text-sm font-semibold text-violet-800">一致性哈希参数</span>
+            <div v-if="formData.upstream_type === 'chash'">
+              <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">哈希依据（hash_on）</label>
+              <select v-model="formData.upstream_hash_on" class="input">
+                <option v-for="o in hashOnOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
+              </select>
+              <p class="text-xs text-slate-400 mt-1">{{ selectedHashOnOption.keyHint }}</p>
             </div>
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
-              <div>
-                <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">哈希依据（hash_on）</label>
-                <select v-model="formData.upstream_hash_on" class="input">
-                  <option v-for="o in hashOnOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
-                </select>
-                <p class="text-xs text-slate-400 mt-1">决定用什么来计算哈希值</p>
-              </div>
-              <div>
-                <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">哈希键（key）</label>
-                <input v-model="formData.upstream_key" type="text" class="input" :placeholder="selectedHashOnOption.keyPlaceholder" />
-                <p class="text-xs text-slate-400 mt-1">{{ selectedHashOnOption.keyHint }}</p>
-              </div>
+            <div v-if="formData.upstream_type === 'chash'">
+              <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">哈希键（key）</label>
+              <input v-model="formData.upstream_key" type="text" class="input" :placeholder="selectedHashOnOption.keyPlaceholder" />
             </div>
           </div>
 
-          <div class="space-y-3">
-            <div
-              v-for="(node, index) in formData.upstream_nodes"
-              :key="`node-${index}`"
-              class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm"
-            >
-              <div class="flex items-center justify-between gap-3 mb-4">
-                <div class="flex items-center gap-3 min-w-0">
-                  <div class="w-9 h-9 rounded-xl bg-indigo-100 text-indigo-700 flex items-center justify-center font-semibold text-sm">{{ index + 1 }}</div>
-                  <div>
-                    <div class="text-sm font-semibold text-slate-800">上游节点 {{ index + 1 }}</div>
-                    <div class="text-xs text-slate-400">支持容器选择或直接手动输入主机与端口</div>
-                  </div>
-                </div>
-                <button type="button" @click="removeUpstreamNode(index)" class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-red-50 text-red-600 hover:bg-red-100 text-xs font-medium transition-colors">
-                  <i class="fas fa-trash"></i>
-                  删除
-                </button>
-              </div>
-
-              <div class="grid grid-cols-1 md:grid-cols-12 gap-4 items-start">
-                <div class="md:col-span-5">
-                  <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">上游主机</label>
-                  <HostSelect
-                    :model-value="node.host"
-                    :containers="containers"
-                    placeholder="127.0.0.1 或 容器名"
-                    @update:modelValue="updateUpstreamNodeHost(index, $event)"
-                  />
-                </div>
-                <div class="md:col-span-4">
-                  <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">上游端口</label>
-                  <PortSelect
-                    :model-value="node.port"
-                    :ports="getPortsByHost(node.host)"
-                    placeholder="8080"
-                    @update:modelValue="updateUpstreamNodePort(index, $event)"
-                  />
-                </div>
-                <div class="md:col-span-3">
-                  <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">节点权重</label>
-                  <input v-model.number="node.weight" type="number" min="0" class="input" placeholder="1" />
-                  <p class="text-xs text-slate-400 mt-1">当前策略 {{ formData.upstream_type }} 下的节点权重。</p>
-                </div>
-              </div>
-            </div>
+          <div class="flex items-center justify-between">
+            <label class="text-sm font-medium text-slate-700">上游节点</label>
+            <button @click="addUpstreamNode()" type="button" class="btn-icon text-indigo-600 hover:bg-indigo-50" title="添加节点"><i class="fas fa-plus text-xs"></i></button>
           </div>
-
-          <div v-if="routeValidationMessage" class="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-700">
-            {{ routeValidationMessage }}
+          <div class="rounded-lg border border-slate-200 overflow-hidden">
+            <table class="w-full text-sm">
+              <thead>
+                <tr class="bg-slate-50 border-b border-slate-200">
+                  <th class="px-3 py-2 text-left text-xs font-semibold text-slate-600 w-1/2">主机</th>
+                  <th class="px-3 py-2 text-left text-xs font-semibold text-slate-600 w-[30%]">端口</th>
+                  <th class="px-3 py-2 text-left text-xs font-semibold text-slate-600 w-[20%]">权重</th>
+                  <th v-if="formData.upstream_nodes.length > 1" class="px-3 py-2 w-8"></th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-slate-100">
+                <tr v-for="(node, index) in formData.upstream_nodes" :key="index">
+                  <td class="px-3 py-2"><HostSelect :model-value="node.host" :containers="containers" placeholder="127.0.0.1 或 容器名" @update:modelValue="updateUpstreamNode(index, 'host', $event)" /></td>
+                  <td class="px-3 py-2"><PortSelect :model-value="node.port" :ports="getPortsByHost(node.host)" placeholder="80" @update:modelValue="updateUpstreamNode(index, 'port', $event)" /></td>
+                  <td class="px-3 py-2"><input v-model.number="node.weight" type="number" class="input" placeholder="1" min="0" /></td>
+                  <td v-if="formData.upstream_nodes.length > 1" class="px-1 py-2 text-center">
+                    <button @click="removeUpstreamNode(index)" type="button" class="btn-icon text-red-400 hover:text-red-600 hover:bg-red-50" title="移除"><i class="fas fa-xmark text-xs"></i></button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
           </div>
+          <div v-if="routeValidationMessage" class="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-700">{{ routeValidationMessage }}</div>
         </div>
 
-        <div v-else-if="formData.upstream_mode === 'upstream_id'" class="rounded-2xl border border-emerald-200 bg-white p-4 shadow-sm space-y-3">
+        <div v-else-if="formData.upstream_mode === 'upstream_id'" class="space-y-3">
           <div>
             <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">选择已有上游</label>
             <select v-model="formData.upstream_id" class="input">
               <option value="">请选择已有上游</option>
-              <option v-for="upstream in upstreams" :key="upstream.id" :value="upstream.id">
-                {{ upstream.name || upstream.id }}（{{ upstream.type || 'roundrobin' }}）
-              </option>
+              <option v-for="upstream in upstreams" :key="upstream.id" :value="upstream.id">{{ upstream.name || upstream.id }}（{{ upstream.type || 'roundrobin' }}）</option>
             </select>
-            <p class="text-xs text-slate-400 mt-1">适用于复用已在 APISIX 中维护的上游对象。</p>
           </div>
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
-            <div class="rounded-xl bg-emerald-50 border border-emerald-100 px-3 py-3 text-xs text-emerald-700">
-              <div class="font-semibold mb-1">为什么用引用模式</div>
-              <div>当多个路由共享同一组上游配置时，只需要维护一个上游对象。</div>
-            </div>
-            <div class="rounded-xl bg-slate-50 border border-slate-200 px-3 py-3 text-xs text-slate-600">
-              <div class="font-semibold mb-1">注意</div>
-              <div>切换为引用模式后，本路由将不再提交内联节点列表。</div>
-            </div>
-          </div>
-          <div v-if="routeValidationMessage" class="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-700">
-            {{ routeValidationMessage }}
-          </div>
+          <div v-if="routeValidationMessage" class="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-700">{{ routeValidationMessage }}</div>
         </div>
 
-        <div v-else class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm space-y-3">
-          <div>
-            <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">暂不配置上游</label>
-            <p class="text-sm text-slate-600 leading-6">当前保存只会提交路由匹配规则、状态和插件配置，不会附带内联节点，也不会引用已有上游。</p>
-          </div>
-          <div class="rounded-xl bg-slate-50 border border-slate-200 px-3 py-3 text-xs text-slate-600">
-            <div class="font-semibold mb-1">适用场景</div>
-            <div>先创建占位路由，后续再由手工或其他流程补充上游配置。</div>
-          </div>
-        </div>
-
+        <div v-else class="text-sm text-slate-500 leading-6">当前保存只会提交路由匹配规则、状态和插件配置，不会附带内联节点，也不会引用已有上游。</div>
       </div>
 
       <div>
-        <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">复用插件配置</label>
+        <label class="block text-sm font-medium text-slate-700 mb-2">复用插件配置</label>
         <select v-model="formData.plugin_config_id" class="input">
           <option value="">不使用</option>
           <option v-for="pc in pluginConfigs" :key="pc.id" :value="pc.id">{{ pc.desc || pc.id }}</option>
         </select>
       </div>
 
-      <div class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+      <div class="border border-slate-200 rounded-xl p-4">
         <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-3 mb-3">
           <div>
             <label class="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">独立插件配置</label>
@@ -735,34 +512,23 @@ export default toNative(RouteEditModal)
         </div>
 
         <div v-if="showPluginPanel" class="mb-3 p-3 bg-slate-50 rounded-xl border border-slate-200">
-          <div class="mb-2">
-            <input v-model="pluginSearchKeyword" type="text" placeholder="搜索插件..." class="input text-xs" />
-          </div>
+          <input v-model="pluginSearchKeyword" type="text" placeholder="搜索插件..." class="input text-xs mb-2" />
           <div class="max-h-40 overflow-y-auto grid grid-cols-1 md:grid-cols-3 gap-2">
             <button
               v-for="name in filteredAvailablePlugins"
               :key="name"
-              @click="addPresetPlugin(name)"
-              :class="[
-                'px-3 py-2 text-xs rounded-xl text-left truncate transition-colors border',
-                formData.plugins[name] !== undefined
-                  ? 'bg-indigo-100 text-indigo-700 border-indigo-200 cursor-default'
-                  : 'bg-white hover:bg-indigo-50 text-slate-700 border-slate-200'
-              ]"
               :disabled="formData.plugins[name] !== undefined"
-            >
-              {{ name }}
-            </button>
+              :class="['px-3 py-2 text-xs rounded-xl text-left truncate transition-colors border', formData.plugins[name] !== undefined ? 'bg-indigo-100 text-indigo-700 border-indigo-200 cursor-default' : 'bg-white hover:bg-indigo-50 text-slate-700 border-slate-200']"
+              @click="addPresetPlugin(name)"
+            >{{ name }}</button>
           </div>
         </div>
 
         <div v-if="showImportPanel" class="mb-3 p-3 bg-slate-50 rounded-xl border border-slate-200">
-          <div class="mb-2">
-            <select v-model="importRouteId" @change="onImportRouteChange" class="input text-xs">
-              <option value="">选择来源路由...</option>
-              <option v-for="r in routes" :key="r.id" :value="r.id">{{ r.name || r.id }}</option>
-            </select>
-          </div>
+          <select v-model="importRouteId" @change="onImportRouteChange" class="input text-xs mb-2">
+            <option value="">选择来源路由...</option>
+            <option v-for="r in routes" :key="r.id" :value="r.id">{{ r.name || r.id }}</option>
+          </select>
           <div v-if="importRoutePluginsLoading" class="text-xs text-slate-500 text-center py-2">加载中...</div>
           <div v-else-if="Object.keys(importRoutePlugins).length > 0">
             <div class="max-h-32 overflow-y-auto space-y-1 mb-2">
@@ -775,11 +541,8 @@ export default toNative(RouteEditModal)
           </div>
         </div>
 
-        <div v-if="currentPluginNames.length > 0" class="flex flex-wrap gap-1.5 mb-3">
-          <span v-for="name in currentPluginNames" :key="name" class="inline-flex items-center gap-1 px-2.5 py-1 bg-indigo-50 text-indigo-700 rounded-full text-xs border border-indigo-100">
-            {{ name }}
-            <button @click="removePlugin(name)" class="hover:text-red-500 transition-colors"><i class="fas fa-xmark text-[10px]"></i></button>
-          </span>
+        <div v-if="currentPluginNames.length > 0" class="flex flex-wrap gap-1 mb-2">
+          <span v-for="name in currentPluginNames" :key="name" class="inline-flex items-center gap-1 px-2 py-0.5 bg-indigo-50 text-indigo-700 rounded text-xs">{{ name }}<button @click="removePlugin(name)" class="hover:text-red-500 transition-colors"><i class="fas fa-xmark text-[10px]"></i></button></span>
         </div>
 
         <textarea v-model="formData.pluginsJson" @blur="syncPluginsFromJson" rows="8" :class="['input font-mono text-sm', formData.pluginsJsonError ? 'border-red-300 bg-red-50' : '']" placeholder='{"key-auth": {}, "proxy-rewrite": {"uri": "/new-path"}}'></textarea>


### PR DESCRIPTION
**Motivation**
- APISIX 路由的上游配置此前仅支持内联节点（nodes）模式，无法引用已在 APISIX 中创建的上游对象，也缺乏对空上游场景的支持

**Change**

- 新增上游多模式支持：在路由编辑弹窗中引入 upstream_mode 字段，支持三种模式——内联多上游节点（nodes）、引用已有上游（upstream_id）和空上游（none），并以卡片式 UI 引导用户选择。

- 增强路由列表页：在路由表格中新增"上游"列，展示上游模式与节点摘要，便于快速概览；扩展搜索范围至 URI、上游等字段。

- 重构路由编辑弹窗结构：将 formData 提取为组件外部的 reactive() 定义，删除自动填充端口的 @Watch 监听器，改为计算属性 selectedInlineNodeCount 和 upstreamModeCards，简化组件逻辑。

- 类型与工具扩展：在 apisix.ts 中新增 ApisixRouteUpstreamMode、ApisixRouteUpstreamModeCard 等类型；在 utils.ts 中新增节点摘要格式化等辅助函数。

- UI 细节优化：调整插件标签为药丸样式、按钮增加阴影、导入插件面板布局微调等。