### PR TITLE
fix(docs): 更新安装脚本的下载链接、Docker 运行命令和端口映射文档

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,12 @@ services:
 
 ```bash
 # 一键安装
-curl -sL https://github.com/rehiy/isrvd/refs/heads/master/script/isrvd.sh | sudo bash -s install
+curl -sL https://raw.githubusercontent.com/rehiy/isrvd/refs/heads/master/build/script/isrvd.sh | sudo bash -s install
 
 # 其他命令
-curl -sL https://github.com/rehiy/isrvd/refs/heads/master/script/isrvd.sh | sudo bash -s update     # 更新
-curl -sL https://github.com/rehiy/isrvd/refs/heads/master/script/isrvd.sh | sudo bash -s uninstall  # 卸载
-curl -sL https://github.com/rehiy/isrvd/refs/heads/master/script/isrvd.sh | bash -s download        # 仅下载
+curl -sL https://raw.githubusercontent.com/rehiy/isrvd/refs/heads/master/build/script/isrvd.sh | sudo bash -s update     # 更新
+curl -sL https://raw.githubusercontent.com/rehiy/isrvd/refs/heads/master/build/script/isrvd.sh | sudo bash -s uninstall  # 卸载
+curl -sL https://raw.githubusercontent.com/rehiy/isrvd/refs/heads/master/build/script/isrvd.sh | bash -s download        # 仅下载
 ```
 
 安装目录：`/usr/local/isrvd/`（包含二进制和配置文件）

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@
 docker run -d \
   --name isrvd \
   -p 8080:8080 \
-  -p 9080:9080 \
+  -p 80:9080 \
+  -p 443:9443 \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v /mnt/isrvd:/data \
   rehiy/isrvd:latest
@@ -44,6 +45,7 @@ docker run -d \
 |------|------|------|
 | 8080 | isrvd | Web 管理界面 |
 | 9080 | APISIX | HTTP 代理端口 |
+| 9443 | APISIX | HTTPS 代理端口 |
 
 ### slim（仅 isrvd）
 


### PR DESCRIPTION
- 将 GitHub raw 链接更新为正确的构建脚本路径
- 修正所有安装、更新、卸载和下载命令的 URL
- 确保脚本从 build 目录而不是根目录获取
- 将 Docker 运行命令中的端口映射从 9080:9080 和 9443:9443 更改为 80:9080 和 443:9443
- 添加 HTTPS 代理端口 9443 到端口映射表中
