### PR TITLE
fix: 添加 DeployResult.Items 的 json tag

### DIFF
--- a/internal/service/compose/service.go
+++ b/internal/service/compose/service.go
@@ -39,9 +39,9 @@ type RedeployRequest struct {
 
 // DeployResult 部署结果
 type DeployResult struct {
-	Target     Target `json:"target"`
-	Items      []string
-	InstallDir string `json:"installDir,omitempty"`
+	Target     Target   `json:"target"`
+	Items      []string `json:"items"`
+	InstallDir string   `json:"installDir,omitempty"`
 }
 
 // ==================== 服务定义 ====================


### PR DESCRIPTION
修复 compose 部署成功后前端无法正确显示已创建容器数量的问题。
Items 字段缺少 json:"items" tag，导致前端接收到的 payload 中 items 字段为空数组。