### PR TITLE
fix: 修正概览页系统字段大小写以对齐后端 JSON

### DIFF
--- a/webview/src/service/types/overview.ts
+++ b/webview/src/service/types/overview.ts
@@ -17,17 +17,17 @@ export interface SystemVersionCheck {
 }
 
 export interface SystemNetInterface {
-    Name: string
-    BytesRecv: number
-    BytesSent: number
+    name: string
+    bytesRecv: number
+    bytesSent: number
 }
 
 export interface SystemDiskPartition {
-    Device: string
-    Mountpoint: string
-    Fstype: string
-    Used: number
-    Total: number
+    device: string
+    mountpoint: string
+    fstype: string
+    used: number
+    total: number
 }
 
 export interface SystemDiskIO {
@@ -40,30 +40,30 @@ export interface SystemGoRuntimeStat {
     version: string
     numCPU: number
     numGoroutine: number
-    HeapAlloc: number
-    HeapInuse: number
-    Sys: number
-    StackInuse: number
-    TotalAlloc: number
-    NumGC: number
-    LastGC: number
+    heapAlloc: number
+    heapInuse: number
+    sys: number
+    stackInuse: number
+    totalAlloc: number
+    numGC: number
+    lastGC: number
 }
 
 export interface SystemInfo {
-    HostName: string
-    Platform: string
-    KernelArch: string
-    Uptime: number
-    CpuCore: number
-    CpuCoreLogic: number
-    CpuModel: string[]
-    CpuPercent: number[]
-    MemoryUsed: number
-    MemoryTotal: number
-    DiskTotal: number
-    DiskUsed: number
-    NetInterface: SystemNetInterface[]
-    DiskPartition: SystemDiskPartition[]
+    hostName: string
+    platform: string
+    kernelArch: string
+    uptime: number
+    cpuCore: number
+    cpuCoreLogic: number
+    cpuModel: string[]
+    cpuPercent: number[]
+    memoryUsed: number
+    memoryTotal: number
+    diskTotal: number
+    diskUsed: number
+    netInterface: SystemNetInterface[]
+    diskPartition: SystemDiskPartition[]
 }
 
 export interface SystemGPU {

--- a/webview/src/views/overview/widget/system_cpu_mem.vue
+++ b/webview/src/views/overview/widget/system_cpu_mem.vue
@@ -25,22 +25,22 @@ class SystemCpuMem extends Vue {
     private cpuHistory: { labels: string[]; data: number[] } = { labels: [], data: [] }
     private memHistory: { labels: string[]; data: number[] } = { labels: [], data: [] }
 
-    current: Pick<SystemStat['system'], 'CpuPercent' | 'CpuModel' | 'MemoryUsed' | 'MemoryTotal'> | null = null
+    current: Pick<SystemStat['system'], 'cpuPercent' | 'cpuModel' | 'memoryUsed' | 'memoryTotal'> | null = null
 
     get cpuVal() {
-        return this.current ? this.avgCpuPercent(this.current.CpuPercent) : 0
+        return this.current ? this.avgCpuPercent(this.current.cpuPercent) : 0
     }
 
     get memVal() {
-        return this.current ? this.memPercent(this.current.MemoryUsed, this.current.MemoryTotal) : 0
+        return this.current ? this.memPercent(this.current.memoryUsed, this.current.memoryTotal) : 0
     }
 
     get cpuModel() {
-        return this.current?.CpuModel?.[0] || ''
+        return this.current?.cpuModel?.[0] || ''
     }
 
-    get memUsed() { return this.current?.MemoryUsed ?? 0 }
-    get memTotal() { return this.current?.MemoryTotal ?? 0 }
+    get memUsed() { return this.current?.memoryUsed ?? 0 }
+    get memTotal() { return this.current?.memoryTotal ?? 0 }
 
     avgCpuPercent(arr: number[]): number {
         if (!arr || !arr.length) return 0
@@ -131,15 +131,15 @@ class SystemCpuMem extends Vue {
 
     pushData(payload: SystemStat) {
         const s = payload.system
-        this.current = { CpuPercent: s.CpuPercent, CpuModel: s.CpuModel, MemoryUsed: s.MemoryUsed, MemoryTotal: s.MemoryTotal }
+        this.current = { cpuPercent: s.cpuPercent, cpuModel: s.cpuModel, memoryUsed: s.memoryUsed, memoryTotal: s.memoryTotal }
 
         const now = new Date()
         const label = `${now.getHours().toString().padStart(2, '0')}:${now.getMinutes().toString().padStart(2, '0')}:${now.getSeconds().toString().padStart(2, '0')}`
 
         this.cpuHistory.labels.push(label)
-        this.cpuHistory.data.push(this.avgCpuPercent(s.CpuPercent))
+        this.cpuHistory.data.push(this.avgCpuPercent(s.cpuPercent))
         this.memHistory.labels.push(label)
-        this.memHistory.data.push(this.memPercent(s.MemoryUsed, s.MemoryTotal))
+        this.memHistory.data.push(this.memPercent(s.memoryUsed, s.memoryTotal))
 
         if (this.cpuHistory.labels.length > MAX_HISTORY) {
             this.cpuHistory.labels.shift()

--- a/webview/src/views/overview/widget/system_disk.vue
+++ b/webview/src/views/overview/widget/system_disk.vue
@@ -28,7 +28,7 @@ class SystemDisk extends Vue {
     private diskIOCharts: Record<string, Chart<'line'>> = {}
     diskIOHistory: Record<string, DiskIOSeriesHistory> = {}
     private lastDiskIO: Record<string, { read: number; write: number; time: number }> = {}
-    current: Pick<SystemStat['system'], 'DiskTotal' | 'DiskUsed' | 'DiskPartition'> | null = null
+    current: Pick<SystemStat['system'], 'diskTotal' | 'diskUsed' | 'diskPartition'> | null = null
     private currentDiskIO: SystemDiskIO[] = []
 
     fmtSize(bytes: number, rates = false) {
@@ -128,10 +128,10 @@ class SystemDisk extends Vue {
 
     pushData(payload: SystemStat) {
         const s = payload.system
-        this.current = { DiskTotal: s.DiskTotal, DiskUsed: s.DiskUsed, DiskPartition: s.DiskPartition }
+        this.current = { diskTotal: s.diskTotal, diskUsed: s.diskUsed, diskPartition: s.diskPartition }
         this.currentDiskIO = payload.diskIO || []
 
-        if (!payload.diskIO?.length || !s.DiskPartition) return
+        if (!payload.diskIO?.length || !s.diskPartition) return
 
         const now = new Date()
         const label = `${now.getHours().toString().padStart(2, '0')}:${now.getMinutes().toString().padStart(2, '0')}:${now.getSeconds().toString().padStart(2, '0')}`
@@ -187,52 +187,52 @@ export default toNative(SystemDisk)
 </script>
 
 <template>
-  <div v-if="current?.DiskPartition?.length" class="rounded-xl border border-slate-200 bg-white overflow-hidden">
+  <div v-if="current?.diskPartition?.length" class="rounded-xl border border-slate-200 bg-white overflow-hidden">
     <div class="px-4 py-3 border-b border-slate-100 flex items-center gap-2">
       <div class="w-6 h-6 rounded-md bg-amber-500 flex items-center justify-center">
         <i class="fas fa-hard-drive text-white text-xs"></i>
       </div>
       <span class="text-sm font-semibold text-slate-700">硬盘 I/O</span>
       <span class="ml-auto text-xs text-slate-400">
-        总计 {{ fmtBytes(current.DiskTotal) }}，已用 {{ fmtBytes(current.DiskUsed) }}
+        总计 {{ fmtBytes(current.diskTotal) }}，已用 {{ fmtBytes(current.diskUsed) }}
       </span>
     </div>
     <div ref="diskIOContainerRef" class="divide-y divide-slate-100">
-      <div v-for="dp in current.DiskPartition" :key="dp.Mountpoint" class="px-4 py-3">
+      <div v-for="dp in current.diskPartition" :key="dp.mountpoint" class="px-4 py-3">
         <div class="flex flex-col gap-2">
           <div class="flex items-center justify-between gap-2">
             <div class="flex items-center gap-2 min-w-0">
-              <p class="text-xs font-semibold text-slate-700 truncate">{{ dp.Mountpoint }}</p>
-              <p class="text-xs text-slate-400 shrink-0">{{ dp.Device }} · {{ dp.Fstype }}</p>
+              <p class="text-xs font-semibold text-slate-700 truncate">{{ dp.mountpoint }}</p>
+              <p class="text-xs text-slate-400 shrink-0">{{ dp.device }} · {{ dp.fstype }}</p>
             </div>
-            <p class="text-xs text-slate-600 font-mono shrink-0">{{ fmtBytes(dp.Used) }} / {{ fmtBytes(dp.Total) }} ({{ memPercent(dp.Used, dp.Total) }}%)</p>
+            <p class="text-xs text-slate-600 font-mono shrink-0">{{ fmtBytes(dp.used) }} / {{ fmtBytes(dp.total) }} ({{ memPercent(dp.used, dp.total) }}%)</p>
           </div>
           <div class="h-1 relative bg-slate-100 rounded overflow-hidden">
-            <div :class="['absolute inset-y-0 left-0 rounded', barColor(memPercent(dp.Used, dp.Total))]" :style="{ width: memPercent(dp.Used, dp.Total) + '%' }"></div>
+            <div :class="['absolute inset-y-0 left-0 rounded', barColor(memPercent(dp.used, dp.total))]" :style="{ width: memPercent(dp.used, dp.total) + '%' }"></div>
           </div>
-          <template v-if="diskIOByDevice(dp.Device)">
+          <template v-if="diskIOByDevice(dp.device)">
             <div class="flex items-center justify-between gap-1">
               <span class="text-xs text-slate-400">IO 速率</span>
               <div class="flex items-center gap-4 text-xs">
                 <span class="flex items-center gap-1">
                   <i class="fas fa-arrow-down text-amber-500"></i>
-                  <span class="font-mono text-slate-600 w-20 text-right">{{ fmtRate(currentDiskRate(devShortName(dp.Device), 'read')) }}</span>
+                  <span class="font-mono text-slate-600 w-20 text-right">{{ fmtRate(currentDiskRate(devShortName(dp.device), 'read')) }}</span>
                 </span>
                 <span class="flex items-center gap-1">
                   <i class="fas fa-arrow-up text-violet-500"></i>
-                  <span class="font-mono text-slate-600 w-20 text-right">{{ fmtRate(currentDiskRate(devShortName(dp.Device), 'write')) }}</span>
+                  <span class="font-mono text-slate-600 w-20 text-right">{{ fmtRate(currentDiskRate(devShortName(dp.device), 'write')) }}</span>
                 </span>
               </div>
             </div>
             <div class="relative h-16 bg-slate-50 rounded-lg overflow-hidden">
-              <canvas :data-disk="devShortName(dp.Device)" class="w-full h-full"></canvas>
-              <div v-if="!diskIOHistory[devShortName(dp.Device)]?.read?.length" class="absolute inset-0 flex items-center justify-center">
+              <canvas :data-disk="devShortName(dp.device)" class="w-full h-full"></canvas>
+              <div v-if="!diskIOHistory[devShortName(dp.device)]?.read?.length" class="absolute inset-0 flex items-center justify-center">
                 <span class="text-xs text-slate-300">等待数据...</span>
               </div>
             </div>
             <div class="flex gap-4 text-xs text-slate-400">
-              <span>累计读: {{ fmtBytes(diskIOByDevice(dp.Device)?.ReadBytes ?? 0) }}</span>
-              <span>累计写: {{ fmtBytes(diskIOByDevice(dp.Device)?.WriteBytes ?? 0) }}</span>
+              <span>累计读: {{ fmtBytes(diskIOByDevice(dp.device)?.ReadBytes ?? 0) }}</span>
+              <span>累计写: {{ fmtBytes(diskIOByDevice(dp.device)?.WriteBytes ?? 0) }}</span>
             </div>
           </template>
         </div>

--- a/webview/src/views/overview/widget/system_go.vue
+++ b/webview/src/views/overview/widget/system_go.vue
@@ -44,31 +44,31 @@ export default toNative(SystemGo)
       </div>
       <div class="px-4 py-3">
         <p class="text-xs text-slate-400 mb-1">堆已分配</p>
-        <p class="text-sm font-bold text-slate-800">{{ fmtSize(current.HeapAlloc) }}</p>
+        <p class="text-sm font-bold text-slate-800">{{ fmtSize(current.heapAlloc) }}</p>
       </div>
       <div class="px-4 py-3">
         <p class="text-xs text-slate-400 mb-1">堆使用中</p>
-        <p class="text-sm font-bold text-slate-800">{{ fmtSize(current.HeapInuse) }}</p>
+        <p class="text-sm font-bold text-slate-800">{{ fmtSize(current.heapInuse) }}</p>
       </div>
       <div class="px-4 py-3">
         <p class="text-xs text-slate-400 mb-1">系统申请</p>
-        <p class="text-sm font-bold text-slate-800">{{ fmtSize(current.Sys) }}</p>
+        <p class="text-sm font-bold text-slate-800">{{ fmtSize(current.sys) }}</p>
       </div>
       <div class="px-4 py-3">
         <p class="text-xs text-slate-400 mb-1">栈使用中</p>
-        <p class="text-sm font-bold text-slate-800">{{ fmtSize(current.StackInuse) }}</p>
+        <p class="text-sm font-bold text-slate-800">{{ fmtSize(current.stackInuse) }}</p>
       </div>
       <div class="px-4 py-3">
         <p class="text-xs text-slate-400 mb-1">累计分配</p>
-        <p class="text-sm font-bold text-slate-800">{{ fmtSize(current.TotalAlloc) }}</p>
+        <p class="text-sm font-bold text-slate-800">{{ fmtSize(current.totalAlloc) }}</p>
       </div>
       <div class="px-4 py-3">
         <p class="text-xs text-slate-400 mb-1">GC 次数</p>
-        <p class="text-sm font-bold text-slate-800">{{ current.NumGC }}</p>
+        <p class="text-sm font-bold text-slate-800">{{ current.numGC }}</p>
       </div>
       <div class="px-4 py-3">
         <p class="text-xs text-slate-400 mb-1">最后 GC</p>
-        <p class="text-sm font-bold text-slate-800">{{ fmtGCTime(current.LastGC) }}</p>
+        <p class="text-sm font-bold text-slate-800">{{ fmtGCTime(current.lastGC) }}</p>
       </div>
     </div>
   </div>

--- a/webview/src/views/overview/widget/system_info.vue
+++ b/webview/src/views/overview/widget/system_info.vue
@@ -45,19 +45,19 @@ export default toNative(SystemInfo)
     </div>
     <div class="rounded-xl border border-slate-200 bg-white p-4">
       <p class="text-xs text-slate-400 mb-1">主机名</p>
-      <p class="text-sm font-semibold text-slate-800 truncate">{{ current.system.HostName }}</p>
+      <p class="text-sm font-semibold text-slate-800 truncate">{{ current.system.hostName }}</p>
     </div>
     <div class="rounded-xl border border-slate-200 bg-white p-4">
       <p class="text-xs text-slate-400 mb-1">操作系统</p>
-      <p class="text-sm font-semibold text-slate-800 truncate">{{ current.system.Platform }} / {{ current.system.KernelArch }}</p>
+      <p class="text-sm font-semibold text-slate-800 truncate">{{ current.system.platform }} / {{ current.system.kernelArch }}</p>
     </div>
     <div class="rounded-xl border border-slate-200 bg-white p-4">
       <p class="text-xs text-slate-400 mb-1">运行时间</p>
-      <p class="text-sm font-semibold text-slate-800">{{ fmtUptime(current.system.Uptime) }}</p>
+      <p class="text-sm font-semibold text-slate-800">{{ fmtUptime(current.system.uptime) }}</p>
     </div>
     <div class="rounded-xl border border-slate-200 bg-white p-4">
       <p class="text-xs text-slate-400 mb-1">CPU 核心</p>
-      <p class="text-sm font-semibold text-slate-800">{{ current.system.CpuCore }} 物理 / {{ current.system.CpuCoreLogic }} 逻辑</p>
+      <p class="text-sm font-semibold text-slate-800">{{ current.system.cpuCore }} 物理 / {{ current.system.cpuCoreLogic }} 逻辑</p>
     </div>
   </div>
 </template>

--- a/webview/src/views/overview/widget/system_network.vue
+++ b/webview/src/views/overview/widget/system_network.vue
@@ -44,7 +44,7 @@ class SystemNetwork extends Vue {
     physicalInterfaces(list: SystemNetInterface[]) {
         if (!list) return []
         const virtualPrefixes = ['lo', 'docker', 'veth', 'br-', 'overlay', 'flannel', 'cni', 'tunl', 'dummy', 'virbr']
-        return list.filter(ni => !virtualPrefixes.some(p => ni.Name.startsWith(p)))
+        return list.filter(ni => !virtualPrefixes.some(p => ni.name.startsWith(p)))
     }
 
     currentRate(name: string, dir: string): number {
@@ -106,7 +106,7 @@ class SystemNetwork extends Vue {
     }
 
     pushData(payload: SystemStat) {
-        const ifaces = payload.system?.NetInterface || []
+        const ifaces = payload.system?.netInterface || []
         this.currentIfaces = this.physicalInterfaces(ifaces)
         if (!ifaces.length) return
 
@@ -115,7 +115,7 @@ class SystemNetwork extends Vue {
         const nowTime = Date.now()
 
         this.physicalInterfaces(ifaces).forEach(ni => {
-            const name = ni.Name
+            const name = ni.name
             const last = this.lastNetIO[name]
 
             let recvRate = 0
@@ -124,12 +124,12 @@ class SystemNetwork extends Vue {
             if (last && last.time > 0) {
                 const dt = (nowTime - last.time) / 1000
                 if (dt > 0) {
-                    recvRate = Math.max(0, (ni.BytesRecv - last.recv) / dt)
-                    sentRate = Math.max(0, (ni.BytesSent - last.sent) / dt)
+                    recvRate = Math.max(0, (ni.bytesRecv - last.recv) / dt)
+                    sentRate = Math.max(0, (ni.bytesSent - last.sent) / dt)
                 }
             }
 
-            this.lastNetIO[name] = { recv: ni.BytesRecv, sent: ni.BytesSent, time: nowTime }
+            this.lastNetIO[name] = { recv: ni.bytesRecv, sent: ni.bytesSent, time: nowTime }
 
             if (!this.netHistory[name]) {
                 this.netHistory[name] = { labels: [], recv: [], sent: [] }
@@ -172,29 +172,29 @@ export default toNative(SystemNetwork)
       <span class="text-sm font-semibold text-slate-700">网络接口</span>
     </div>
     <div ref="netContainerRef" class="divide-y divide-slate-100">
-      <div v-for="ni in currentIfaces" :key="ni.Name" class="px-4 py-3">
+      <div v-for="ni in currentIfaces" :key="ni.name" class="px-4 py-3">
         <div class="flex flex-col sm:flex-row sm:items-center justify-between mb-2 gap-1">
-          <p class="text-xs font-semibold text-slate-700">{{ ni.Name }}</p>
+          <p class="text-xs font-semibold text-slate-700">{{ ni.name }}</p>
           <div class="flex items-center gap-4 text-xs">
             <span class="flex items-center gap-1">
               <i class="fas fa-arrow-down text-emerald-500"></i>
-              <span class="font-mono text-slate-600 w-20 text-right">{{ fmtRate(currentRate(ni.Name, 'recv')) }}</span>
+              <span class="font-mono text-slate-600 w-20 text-right">{{ fmtRate(currentRate(ni.name, 'recv')) }}</span>
             </span>
             <span class="flex items-center gap-1">
               <i class="fas fa-arrow-up text-blue-500"></i>
-              <span class="font-mono text-slate-600 w-20 text-right">{{ fmtRate(currentRate(ni.Name, 'sent')) }}</span>
+              <span class="font-mono text-slate-600 w-20 text-right">{{ fmtRate(currentRate(ni.name, 'sent')) }}</span>
             </span>
           </div>
         </div>
         <div class="relative h-20 bg-slate-50 rounded-lg overflow-hidden">
-          <canvas :data-iface="ni.Name" class="w-full h-full"></canvas>
-          <div v-if="!netHistory[ni.Name]?.labels?.length" class="absolute inset-0 flex items-center justify-center">
+          <canvas :data-iface="ni.name" class="w-full h-full"></canvas>
+          <div v-if="!netHistory[ni.name]?.labels?.length" class="absolute inset-0 flex items-center justify-center">
             <span class="text-xs text-slate-300">等待数据...</span>
           </div>
         </div>
         <div class="flex flex-col sm:flex-row gap-2 sm:gap-4 mt-1.5 text-xs text-slate-400">
-          <span>累计收: {{ fmtBytes(ni.BytesRecv) }}</span>
-          <span>累计发: {{ fmtBytes(ni.BytesSent) }}</span>
+          <span>累计收: {{ fmtBytes(ni.bytesRecv) }}</span>
+          <span>累计发: {{ fmtBytes(ni.bytesSent) }}</span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- 后端 `psutil.DetailStat` 与 `GoMemoryStat` 的 JSON 标签为 camelCase（`hostName`/`platform`/`kernelArch`/`uptime`/`cpuCore`/`cpuCoreLogic`/`memoryUsed`/`heapAlloc` 等），前端类型与模板仍按 PascalCase 取值，导致概览页主机名、操作系统、运行时间、CPU 核心、内存、硬盘、网络、Go 运行态字段全部读不到。
- 同步前端 `SystemInfo`/`SystemNetInterface`/`SystemDiskPartition`/`SystemGoRuntimeStat` 类型字段为 camelCase，并更新 `system_info.vue`、`system_cpu_mem.vue`、`system_disk.vue`、`system_network.vue`、`system_go.vue` 的字段访问。
- `SystemDiskIO` 保持 PascalCase（后端 `DiskIOStat` JSON 标签即为 `Name`/`ReadBytes`/`WriteBytes`）。

## Test plan
- [x] `vue-tsc --noEmit` 通过
- [x] 访问 `/overview` 验证各面板字段正常显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)