### PR TITLE
feat: 深色模式三态切换并持久化

### DIFF
--- a/webview/src/component/user-menu.vue
+++ b/webview/src/component/user-menu.vue
@@ -1,11 +1,17 @@
 <script lang="ts">
 import { Component, Vue, toNative } from 'vue-facing-decorator'
 
-import { toggleTheme } from '@/helper/utils'
+import { cycleTheme, getThemeMode, type ThemeMode } from '@/helper/utils'
 
 import Dropdown from '@/component/dropdown.vue'
 
 import { usePortal } from '@/stores'
+
+const THEME_META: Record<ThemeMode, { icon: string; label: string }> = {
+    light: { icon: 'fas fa-sun', label: '浅色' },
+    dark: { icon: 'fas fa-moon', label: '深色' },
+    system: { icon: 'fas fa-desktop', label: '跟随系统' }
+}
 
 @Component({
     components: { Dropdown }
@@ -15,10 +21,14 @@ class UserMenu extends Vue {
 
     // ─── 数据属性 ───
     menuOpen = false
+    themeMode: ThemeMode = getThemeMode()
+
+    get themeIcon() { return THEME_META[this.themeMode].icon }
+    get themeLabel() { return THEME_META[this.themeMode].label }
 
     // ─── 方法 ───
     toggleTheme() {
-        toggleTheme()
+        this.themeMode = cycleTheme()
     }
 
     handleLogout() {
@@ -64,13 +74,14 @@ export default toNative(UserMenu)
       个人设置
     </router-link>
 
-    <!-- 暗黑模式切换 -->
+    <!-- 主题切换：浅色 / 深色 / 跟随系统 -->
     <button
       class="w-full flex items-center gap-3 px-4 py-3 text-sm font-medium text-slate-600 hover:text-blue-600 hover:bg-blue-50 transition-colors"
-      @click="toggleTheme"
+      :title="`当前：${themeLabel}，点击切换`"
+      @click.stop="toggleTheme"
     >
-      <i class="fas fa-moon"></i>
-      <span>切换主题</span>
+      <i :class="themeIcon" class="w-4 text-center"></i>
+      <span>主题：{{ themeLabel }}</span>
     </button>
 
     <!-- 分割线 -->

--- a/webview/src/helper/utils.ts
+++ b/webview/src/helper/utils.ts
@@ -171,23 +171,17 @@ export const copyToClipboard = async (text: string): Promise<boolean> => {
 
 // ─── 主题 ───
 
-/** 根据 localStorage 或系统偏好初始化主题 */
+/** 根据 localStorage 或系统偏好初始化主题，用户的显式选择优先于系统偏好 */
 export const initTheme = (): void => {
     const stored = localStorage.getItem('app-theme')
-    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
-    if (stored === 'dark' || (!stored && prefersDark)) {
-        document.documentElement.classList.add('dark')
-    } else {
-        document.documentElement.classList.remove('dark')
-    }
+    const isDark = stored
+        ? stored === 'dark'
+        : window.matchMedia('(prefers-color-scheme: dark)').matches
+    document.documentElement.classList.toggle('dark', isDark)
 }
 
-/** 切换主题：强制暗色时写入 localStorage，切回亮色时删除（恢复跟随系统）*/
+/** 切换主题并将用户选择持久化到 localStorage */
 export const toggleTheme = (): void => {
     const isDark = document.documentElement.classList.toggle('dark')
-    if (isDark) {
-        localStorage.setItem('app-theme', 'dark')
-    } else {
-        localStorage.removeItem('app-theme')
-    }
+    localStorage.setItem('app-theme', isDark ? 'dark' : 'light')
 }

--- a/webview/src/helper/utils.ts
+++ b/webview/src/helper/utils.ts
@@ -171,17 +171,45 @@ export const copyToClipboard = async (text: string): Promise<boolean> => {
 
 // ─── 主题 ───
 
-/** 根据 localStorage 或系统偏好初始化主题，用户的显式选择优先于系统偏好 */
-export const initTheme = (): void => {
-    const stored = localStorage.getItem('app-theme')
-    const isDark = stored
-        ? stored === 'dark'
-        : window.matchMedia('(prefers-color-scheme: dark)').matches
+export type ThemeMode = 'light' | 'dark' | 'system'
+
+const THEME_KEY = 'app-theme'
+const THEME_ORDER: ThemeMode[] = ['system', 'light', 'dark']
+
+const prefersDark = (): boolean => window.matchMedia('(prefers-color-scheme: dark)').matches
+
+const applyTheme = (mode: ThemeMode): void => {
+    const isDark = mode === 'dark' || (mode === 'system' && prefersDark())
     document.documentElement.classList.toggle('dark', isDark)
 }
 
-/** 切换主题并将用户选择持久化到 localStorage */
-export const toggleTheme = (): void => {
-    const isDark = document.documentElement.classList.toggle('dark')
-    localStorage.setItem('app-theme', isDark ? 'dark' : 'light')
+/** 读取已保存的主题模式，未保存则视为 system */
+export const getThemeMode = (): ThemeMode => {
+    const stored = localStorage.getItem(THEME_KEY)
+    return stored === 'light' || stored === 'dark' ? stored : 'system'
+}
+
+/** 根据 localStorage 或系统偏好初始化主题，并在 system 模式下跟随系统切换 */
+export const initTheme = (): void => {
+    applyTheme(getThemeMode())
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+        if (getThemeMode() === 'system') applyTheme('system')
+    })
+}
+
+/** 设置主题：light/dark 持久化，system 清除存储以恢复跟随系统 */
+export const setThemeMode = (mode: ThemeMode): void => {
+    if (mode === 'system') {
+        localStorage.removeItem(THEME_KEY)
+    } else {
+        localStorage.setItem(THEME_KEY, mode)
+    }
+    applyTheme(mode)
+}
+
+/** 在 system → light → dark → system 三态间循环切换 */
+export const cycleTheme = (): ThemeMode => {
+    const next = THEME_ORDER[(THEME_ORDER.indexOf(getThemeMode()) + 1) % THEME_ORDER.length]
+    setThemeMode(next)
+    return next
 }


### PR DESCRIPTION
## Summary
- 主题切换扩展为「跟随系统 / 浅色 / 深色」三态循环：`light`/`dark` 写入 `localStorage`，`system` 清除存储恢复跟随系统。
- `initTheme` 监听 `prefers-color-scheme` 变化，仅在 `system` 模式下跟随，避免用户的显式选择被系统偏好覆盖。
- 用户菜单项展示当前模式（图标 + 浅色/深色/跟随系统），点击循环切换；保持菜单打开便于继续调整。

## 背景
此前 `toggleTheme` 切回浅色时只是 `removeItem('app-theme')`，下次 `initTheme` 读到 `null` 又回退到 `prefers-color-scheme`；系统是深色时用户切到浅色后刷新会被拉回深色，体感"没保存"。

## Test plan
- [x] `vue-tsc --noEmit` 通过
- [x] 系统深色：切到浅色后刷新仍为浅色；再点回到深色 / 跟随系统
- [x] 系统浅色：切到深色后刷新仍为深色
- [x] 跟随系统模式下，系统切换 light/dark 时页面实时跟随
- [x] 全新访客首次进入跟随系统偏好