### PR TITLE
feat: 新增 Docker 镜像清理接口

### DIFF
--- a/internal/server/ctrl_docker.go
+++ b/internal/server/ctrl_docker.go
@@ -30,6 +30,7 @@ func (app *App) defineDockerRoutes() []Route {
 		{Method: "POST", Path: "/docker/image/:id/tag", Handler: app.dockerImageTag, Module: "docker", Label: "标记镜像"},
 		{Method: "GET", Path: "/docker/image/:id", Handler: app.dockerImageInspect, Module: "docker", Label: "查看镜像"},
 		{Method: "POST", Path: "/docker/image/build", Handler: app.dockerImageBuild, Module: "docker", Label: "构建镜像"},
+		{Method: "POST", Path: "/docker/image/prune", Handler: app.dockerImagePrune, Module: "docker", Label: "清理镜像"},
 		{Method: "POST", Path: "/docker/image/push", Handler: app.dockerImagePush, Module: "docker", Label: "推送镜像"},
 		{Method: "POST", Path: "/docker/image/pull", Handler: app.dockerImagePull, Module: "docker", Label: "拉取镜像"},
 		// 网络管理
@@ -216,6 +217,23 @@ func (app *App) dockerImageBuild(c *gin.Context) {
 		return
 	}
 	respondSuccess(c, "镜像构建成功", result)
+}
+
+func (app *App) dockerImagePrune(c *gin.Context) {
+	var req pkgdocker.ImagePruneRequest
+	// 请求体可选；缺省时仅清理悬空层
+	if c.Request.ContentLength > 0 {
+		if err := c.ShouldBindJSON(&req); err != nil {
+			respondError(c, http.StatusBadRequest, err.Error())
+			return
+		}
+	}
+	result, err := app.dockerSvc.ImagePrune(c.Request.Context(), req)
+	if err != nil {
+		respondError(c, http.StatusInternalServerError, err.Error())
+		return
+	}
+	respondSuccess(c, "镜像清理成功", result)
 }
 
 func (app *App) dockerImageInspect(c *gin.Context) {

--- a/internal/service/docker/image.go
+++ b/internal/service/docker/image.go
@@ -39,6 +39,11 @@ func (s *Service) ImageBuild(ctx context.Context, req pkgdocker.ImageBuildReques
 	return map[string]string{"tag": req.Tag, "message": msg}, nil
 }
 
+// ImagePrune 清理未使用的镜像
+func (s *Service) ImagePrune(ctx context.Context, req pkgdocker.ImagePruneRequest) (*pkgdocker.ImagePruneReport, error) {
+	return s.docker.ImagePrune(ctx, req)
+}
+
 // ImageInspect 获取镜像详情
 func (s *Service) ImageInspect(ctx context.Context, id string) (*pkgdocker.ImageDetail, error) {
 	if id == "" {

--- a/pkgs/docker/image.go
+++ b/pkgs/docker/image.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types/build"
+	"github.com/docker/docker/api/types/filters"
 	dockerimage "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/registry"
 	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
@@ -56,6 +57,53 @@ func (s *DockerService) ImageList(ctx context.Context, all bool) ([]*ImageInfo, 
 	}
 
 	return result, nil
+}
+
+// ImagePruneRequest 镜像清理请求
+type ImagePruneRequest struct {
+	// All 为 true 时清理所有未被任何容器使用的镜像（包括有标签的）；
+	// 为 false 时仅清理悬空（未打标签）的镜像层，即 Docker 默认行为。
+	All bool `json:"all"`
+	// Until 仅清理在该时间之前创建的镜像，格式参考 Docker filters（如 "24h"、"2024-01-01T00:00:00"）。
+	Until string `json:"until,omitempty"`
+}
+
+// ImagePruneReport 镜像清理结果
+type ImagePruneReport struct {
+	ImagesDeleted  []ImagePruneDeleted `json:"imagesDeleted"`
+	SpaceReclaimed uint64              `json:"spaceReclaimed"`
+}
+
+// ImagePruneDeleted 单次删除条目（解除标签 / 删除层）
+type ImagePruneDeleted struct {
+	Untagged string `json:"untagged,omitempty"`
+	Deleted  string `json:"deleted,omitempty"`
+}
+
+// ImagePrune 清理未使用的镜像。
+// dangling=true 仅清理悬空层；dangling=false 等价于 `docker image prune -a`，
+// 会回收所有未被容器引用的镜像（包括有标签但闲置的）。
+func (s *DockerService) ImagePrune(ctx context.Context, req ImagePruneRequest) (*ImagePruneReport, error) {
+	args := filters.NewArgs()
+	// dangling 过滤器为 Docker prune 必填项；true=仅悬空，false=全部未用
+	args.Add("dangling", fmt.Sprintf("%t", !req.All))
+	if req.Until != "" {
+		args.Add("until", req.Until)
+	}
+
+	report, err := s.client.ImagesPrune(ctx, args)
+	if err != nil {
+		logman.Error("Prune images failed", "all", req.All, "error", err)
+		return nil, err
+	}
+
+	deleted := make([]ImagePruneDeleted, 0, len(report.ImagesDeleted))
+	for _, d := range report.ImagesDeleted {
+		deleted = append(deleted, ImagePruneDeleted{Untagged: d.Untagged, Deleted: d.Deleted})
+	}
+
+	logman.Info("Images pruned", "all", req.All, "deletedCount", len(deleted), "spaceReclaimed", report.SpaceReclaimed)
+	return &ImagePruneReport{ImagesDeleted: deleted, SpaceReclaimed: report.SpaceReclaimed}, nil
 }
 
 // ImageActionRequest 镜像操作请求

--- a/skills/isrvd/SKILL.md
+++ b/skills/isrvd/SKILL.md
@@ -29,7 +29,7 @@ isrvd_token "$ISRVD_APIURL" "$ISRVD_APITOKEN"
 | 文档 | 覆盖内容 |
 |------|----------|
 | [docs/docker/containers.md](docs/docker/containers.md) | 容器列表、创建、操作、日志、stats、终端 |
-| [docs/docker/images.md](docs/docker/images.md) | 镜像列表、详情、搜索、构建、标签、拉取、推送、删除 |
+| [docs/docker/images.md](docs/docker/images.md) | 镜像列表、详情、搜索、构建、标签、拉取、推送、删除、清理（prune） |
 | [docs/docker/networks.md](docs/docker/networks.md) | 网络列表、详情、创建、删除 |
 | [docs/docker/volumes.md](docs/docker/volumes.md) | 数据卷列表、详情、创建、删除 |
 | [docs/docker/registries.md](docs/docker/registries.md) | 镜像仓库 CRUD |

--- a/skills/isrvd/docs/docker/images.md
+++ b/skills/isrvd/docs/docker/images.md
@@ -60,6 +60,35 @@ isrvd_post "/docker/image/<IMAGE_ID>/tag" '{"repoTag":"<REPO>/<NAME>:<TAG>"}'
 isrvd_post "/docker/image/<IMAGE_ID>/action" '{"action":"remove"}'
 ```
 
+## 清理未使用镜像
+
+```bash
+# 仅清理悬空层（未打 tag 的中间/失标层）
+isrvd_post "/docker/image/prune" '{}'
+
+# 清理所有未被容器引用的镜像（含有 tag 但闲置的）
+isrvd_post "/docker/image/prune" '{"all":true}'
+
+# 按时间过滤：仅清理 24 小时前创建的镜像
+isrvd_post "/docker/image/prune" '{"all":true,"until":"24h"}'
+```
+
+请求字段：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| all | bool | `false`（默认）仅清理悬空层；`true` 清理所有未被容器引用的镜像 |
+| until | string | 仅清理在该时间之前创建的镜像（Docker filters 语法，如 `24h`、`2024-01-01T00:00:00`） |
+
+响应字段：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| imagesDeleted | object[] | 删除条目，元素含 `untagged` 与/或 `deleted` |
+| imagesDeleted[].untagged | string | 被解除的 tag 引用 |
+| imagesDeleted[].deleted | string | 被删除的镜像层 ID（`sha256:...`） |
+| spaceReclaimed | number | 回收磁盘空间（字节） |
+
 ## 拉取镜像
 
 ```bash


### PR DESCRIPTION
## Summary
新增 `POST /docker/image/prune`，对接 Docker Engine `images prune`，用于回收闲置镜像与层。

请求体（均为可选）：
- `all` (bool)：
  - `false`（默认）：仅清理悬空（dangling）层，即未打 tag 的中间/失标镜像层。
  - `true`：等价 `docker image prune -a`，清理所有未被容器引用的镜像（含有 tag 但闲置的）。
- `until` (string)：仅清理在该时间之前创建的镜像，沿用 Docker filters 语法（如 `24h`、`2024-01-01T00:00:00`）。

响应：
```json
{
  "imagesDeleted": [{ "untagged": "...", "deleted": "sha256:..." }],
  "spaceReclaimed": 123456789
}
```

## 改动
- `pkgs/docker/image.go`：新增 `ImagePruneRequest` / `ImagePruneReport` / `ImagePrune`，封装 `client.ImagesPrune`，按 `all` 设置 `dangling` 过滤器。
- `internal/service/docker/image.go`：服务层透传。
- `internal/server/ctrl_docker.go`：注册路由与 handler，请求体可省略。
- `skills/isrvd/docs/docker/images.md` + `SKILL.md`：同步补充用法、字段表与索引覆盖范围。

## Test plan
- [x] `go build ./...` 通过
- [ ] `POST /docker/image/prune` 空 body：仅清理悬空层
- [ ] `POST /docker/image/prune {"all":true}`：清理所有未引用镜像
- [ ] `POST /docker/image/prune {"all":true,"until":"24h"}`：按时间过滤
- [ ] 正在被容器引用的镜像不被删除