### PR TITLE
[codex] 修复系统监控导航权限判断

### DIFF
--- a/docs/references/overview.md
+++ b/docs/references/overview.md
@@ -49,6 +49,8 @@ isrvd_get "/overview/monitor?type=host&since=86400"  # 最近24小时
 isrvd_get "/overview/monitor?type=container&since=3600&id=<CONTAINER_ID>"
 ```
 
+前端 `/local/monitor` 入口按 `GET /api/overview/monitor` 权限显示。
+
 **查询参数：**
 
 | 参数 | 类型 | 必填 | 说明 |

--- a/webview/src/component/navigation.vue
+++ b/webview/src/component/navigation.vue
@@ -221,7 +221,7 @@ export default toNative(NavigationBar)
         <span v-if="!collapsed">概览</span>
       </router-link>
       <!-- 本机管理折叠子菜单 -->
-      <div v-if="portal.hasPerm('GET /api/filer/files') || portal.hasPerm('GET /api/shell')">
+      <div v-if="portal.hasPerm('GET /api/overview/monitor') || portal.hasPerm('GET /api/filer/files') || portal.hasPerm('GET /api/shell')">
         <!-- 折叠状态只显示图标，点击展开侧边栏 -->
         <button v-if="collapsed" class="nav-link justify-center" :class="{ 'bg-blue-50 text-blue-700': isLocalActive }" title="本机管理" @click.stop="toggleLocal">
           <i class="fas fa-computer"></i>


### PR DESCRIPTION
## 改动内容

- 将“系统监控”入口纳入“本机管理”父菜单显示判断。
- 系统监控页面入口仍通过 portal.hasPerm('GET /api/overview/monitor') 判断，保持现有权限判断风格。
- 补充 overview 文档说明：前端 /local/monitor 入口按 GET /api/overview/monitor 权限显示。

## 问题原因

子菜单项本身按 GET /api/overview/monitor 判断，但“本机管理”父菜单此前只看文件管理和 Shell 权限。用户只有系统监控接口权限时，父菜单不会显示，导致无法进入该页面。

## 验证

- npm run lint
- npm run format:check（通过；提示既有无关文件会被格式化）
- python3 scripts/review-style.py