### PR TITLE
feat: 支持仅 OIDC 登录模式

### DIFF
--- a/config/types.go
+++ b/config/types.go
@@ -40,6 +40,7 @@ type THAConfig struct {
 // OIDC 登陆配置
 type OIDCConfig struct {
 	Enabled       bool     `yaml:"enabled" json:"enabled"`                     // 是否启用 OIDC 登录
+	Only          bool     `yaml:"only" json:"only"`                           // 是否仅允许 OIDC 交互式登录
 	IssuerURL     string   `yaml:"issuerUrl" json:"issuerUrl"`                 // OIDC 提供者 Issuer 地址
 	ClientID      string   `yaml:"clientId" json:"clientId"`                   // OIDC 客户端 ID
 	ClientSecret  string   `yaml:"clientSecret" json:"clientSecret,omitempty"` // 写入时为空表示保留原值；响应时不返回

--- a/docs/references/system/account.md
+++ b/docs/references/system/account.md
@@ -27,6 +27,7 @@ isrvd_post "/account/login" '{"username":"<USER>","password":"<PASS>","totpCode"
 | totpCode | string | TOTP 二次验证码；仅账号启用 TOTP 且密码登录时需要 |
 
 > 通常使用 `isrvd_login` 命令而非直接调用此接口。启用 TOTP 后可使用 `isrvd_login <base_url> <username> <password> <totpCode>`，或使用已创建的 API Token。
+> 当系统配置 `oidc.only=true` 时，该接口会拒绝账号密码登录，请使用 OIDC 登录入口。
 
 ## OIDC 登录
 
@@ -46,6 +47,7 @@ isrvd_post "/account/oidc/exchange" '{"code":"<OIDC_CODE>"}'
 返回：`{"token": "eyJ...", "username": "<USER>"}`
 
 > OIDC 提取的用户名由 `oidc.usernameClaim` 指定，默认 `sub`，必须存在于 `members.username`；不存在时与代理 Header 登录一致，登录失败且不会自动创建成员。一次性 `oidc_code` 是短期凭证，勿复制或写入外部日志；代理 Header 登录模式下不显示 OIDC 登录入口。
+> `oidc.only=true` 时仅禁用账号密码和 Passkey 交互式登录；OIDC 登录成功后仍签发系统 JWT，成员权限和 API Token 能力保持不变。
 
 ## 列出路由权限
 
@@ -128,6 +130,8 @@ isrvd_get "/account/members"
 isrvd_post "/account/member" '{"username":"<USER>","password":"<PASS>","homeDirectory":"<HOME_DIR>","description":"<DESC>","permissions":["GET /api/docker/containers","GET /api/docker/images"]}'
 ```
 
+> `oidc.only=true` 时 `password` 可留空，成员仍用于匹配 OIDC 用户、授权和设置家目录；普通登录模式下新建成员必须提供密码。
+
 ## 更新成员
 
 ```bash
@@ -143,6 +147,8 @@ isrvd_delete "/account/member/<USER>"
 ```
 
 ## Passkey 登录（无需认证）
+
+> 当系统配置 `oidc.only=true` 时，Passkey 登录接口会拒绝登录，请使用 OIDC 登录入口。
 
 ```bash
 # 开始登录（username 为空则使用可发现凭证）

--- a/docs/references/system/config.md
+++ b/docs/references/system/config.md
@@ -58,7 +58,7 @@ isrvd_get "/system/config"
 |------|------|------|
 | server | object | `{listenAddr, rootDirectory, maxUploadSize, allowedOrigins, jwtExpiration, debug, openapi}`（jwtSecret 不返回，写入时位于 JWT 配置项；`openapi`=是否对外提供 `/openapi/` 文档，默认 false） |
 | tha | object | `{enabled, headerName, trustedCIDRs}`（代理 Header 登录配置） |
-| oidc | object | `{enabled, issuerUrl, clientId, redirectUrl, usernameClaim, scopes, loginLabel}`（clientSecret 不返回） |
+| oidc | object | `{enabled, only, issuerUrl, clientId, redirectUrl, usernameClaim, scopes, loginLabel}`（clientSecret 不返回） |
 | passkey | object | `{enabled, rpName, rpId, rpOrigins, timeout}` |
 | agent | object | `{model, baseUrl}`（apiKey 不返回） |
 | apisix | object | `{adminUrl}`（adminKey 不返回） |
@@ -84,6 +84,7 @@ isrvd_put "/system/config" '<CURRENT_CONFIG_WITH_CHANGES>'
 - `oidc.redirectUrl` 生产环境建议显式配置固定 HTTPS 地址；留空会按当前请求 Host 自动生成，适合本地开发。
 - `oidc.usernameClaim` 默认 `sub`；如改用 `email`，需确保 IdP 已验证邮箱且本地 `members.username` 与邮箱完全一致。
 - `oidc.loginLabel` 自定义 OIDC 登录按钮显示名称；留空则使用默认文案"使用 OIDC 登录"。
+- `oidc.only` 开启后仅允许 OIDC 交互式登录，账号密码登录和 Passkey 登录入口会被禁用；OIDC 登录成功后仍签发系统 JWT，成员权限和 API Token 能力保持不变。开启前必须同时启用 `oidc.enabled` 并配置 `oidc.issuerUrl`、`oidc.clientId`，且不能与代理 Header 登录同时启用。
 
 ---
 

--- a/internal/server/ctrl_account.go
+++ b/internal/server/ctrl_account.go
@@ -269,7 +269,7 @@ func (app *App) accountMemberCreate(c *gin.Context) {
 	}
 	if err := app.accountSvc.MemberCreate(req); err != nil {
 		switch {
-		case errors.Is(err, svcAccount.ErrInvalidRequest), errors.Is(err, svcAccount.ErrMemberExists):
+		case errors.Is(err, svcAccount.ErrInvalidRequest), errors.Is(err, svcAccount.ErrMemberExists), errors.Is(err, svcAccount.ErrPasswordRequired):
 			respondError(c, http.StatusBadRequest, err.Error())
 		default:
 			respondError(c, http.StatusInternalServerError, err.Error())

--- a/internal/service/account/auth.go
+++ b/internal/service/account/auth.go
@@ -37,6 +37,7 @@ type AuthInfoResponse struct {
 	Username       string      `json:"username,omitempty"` // 当前登录用户名（未登录时为空）
 	Member         *MemberInfo `json:"member,omitempty"`   // 成员详细信息
 	OIDCEnabled    bool        `json:"oidcEnabled"`        // 是否启用 OIDC 登录
+	OIDCOnly       bool        `json:"oidcOnly"`           // 是否仅允许 OIDC 交互式登录
 	OIDCBtnLabel   string      `json:"oidcBtnLabel"`       // OIDC 登录按钮文案
 	PasskeyEnabled bool        `json:"passkeyEnabled"`     // 是否启用 Passkey 登录
 }
@@ -48,12 +49,14 @@ func (s *Service) AuthInfo(username string) *AuthInfoResponse {
 		mode = "header"
 	}
 	oidcEnabled := mode == "jwt" && config.OIDC.Enabled && config.OIDC.IssuerURL != "" && config.OIDC.ClientID != ""
+	oidcOnly := oidcEnabled && s.OIDCOnly()
 	resp := &AuthInfoResponse{
 		Mode:           mode,
 		Username:       username,
 		Member:         s.MemberInspect(username),
 		OIDCEnabled:    oidcEnabled,
-		PasskeyEnabled: s.PasskeyEnabled(),
+		OIDCOnly:       oidcOnly,
+		PasskeyEnabled: !oidcOnly && s.PasskeyEnabled(),
 	}
 	if oidcEnabled {
 		resp.OIDCBtnLabel = config.OIDC.LoginLabel
@@ -79,6 +82,9 @@ type LoginResponse struct {
 
 // Login 校验用户名密码并签发 JWT Token
 func (s *Service) Login(req LoginRequest) (*LoginResponse, error) {
+	if s.OIDCOnly() {
+		return nil, fmt.Errorf("仅允许 OIDC 登录")
+	}
 	member, exists := config.Members[req.Username]
 	if !exists || !secure.BcryptVerify(req.Password, member.Password) {
 		logman.Warn("Login failed", "username", req.Username)
@@ -99,6 +105,11 @@ func (s *Service) Login(req LoginRequest) (*LoginResponse, error) {
 	}
 	logman.Info("User logged in", "username", req.Username)
 	return resp, nil
+}
+
+// OIDCOnly 返回当前是否仅允许 OIDC 交互式登录。
+func (s *Service) OIDCOnly() bool {
+	return config.OIDC != nil && config.OIDC.Enabled && config.OIDC.Only
 }
 
 // IssueLoginToken 为已存在成员签发登录 JWT Token

--- a/internal/service/account/auth_test.go
+++ b/internal/service/account/auth_test.go
@@ -1,0 +1,80 @@
+package account
+
+import (
+	"testing"
+
+	"github.com/rehiy/libgo/secure"
+
+	"isrvd/config"
+)
+
+func withAccountConfig(t *testing.T, oidc *config.OIDCConfig, passkey *config.PasskeyConfig, members map[string]*config.MemberConfig) {
+	t.Helper()
+	oldOIDC := config.OIDC
+	oldPasskey := config.Passkey
+	oldServer := config.Server
+	oldMembers := config.Members
+	config.OIDC = oidc
+	config.Passkey = passkey
+	config.Server = &config.ServerConfig{JWTSecret: "test-secret", JWTExpiration: 86400}
+	config.Members = members
+	t.Cleanup(func() {
+		config.OIDC = oldOIDC
+		config.Passkey = oldPasskey
+		config.Server = oldServer
+		config.Members = oldMembers
+	})
+}
+
+func TestLoginRejectsPasswordWhenOIDCOnly(t *testing.T) {
+	hash, err := secure.BcryptHash("secret")
+	if err != nil {
+		t.Fatalf("hash password: %v", err)
+	}
+	withAccountConfig(t,
+		&config.OIDCConfig{Enabled: true, Only: true, IssuerURL: "https://idp.example.com", ClientID: "isrvd"},
+		&config.PasskeyConfig{},
+		map[string]*config.MemberConfig{"alice": {Username: "alice", Password: hash}},
+	)
+
+	_, err = (&Service{}).Login(LoginRequest{Username: "alice", Password: "secret"})
+	if err == nil || err.Error() != "仅允许 OIDC 登录" {
+		t.Fatalf("expected OIDC-only login error, got %v", err)
+	}
+}
+
+func TestLoginPasswordWhenOIDCOnlyDisabled(t *testing.T) {
+	hash, err := secure.BcryptHash("secret")
+	if err != nil {
+		t.Fatalf("hash password: %v", err)
+	}
+	withAccountConfig(t,
+		&config.OIDCConfig{Enabled: true, IssuerURL: "https://idp.example.com", ClientID: "isrvd"},
+		&config.PasskeyConfig{},
+		map[string]*config.MemberConfig{"alice": {Username: "alice", Password: hash}},
+	)
+
+	resp, err := (&Service{}).Login(LoginRequest{Username: "alice", Password: "secret"})
+	if err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	if resp == nil || resp.Token == "" || resp.Username != "alice" {
+		t.Fatalf("unexpected login response: %#v", resp)
+	}
+}
+
+func TestAuthInfoDisablesPasskeyInOIDCOnly(t *testing.T) {
+	withAccountConfig(t,
+		&config.OIDCConfig{Enabled: true, Only: true, IssuerURL: "https://idp.example.com", ClientID: "isrvd"},
+		&config.PasskeyConfig{},
+		map[string]*config.MemberConfig{"alice": {Username: "alice"}},
+	)
+
+	resp := (&Service{webAuthn: nil}).AuthInfo("")
+	if !resp.OIDCEnabled || !resp.OIDCOnly {
+		t.Fatalf("expected OIDC-only auth info, got %#v", resp)
+	}
+	if resp.PasskeyEnabled {
+		t.Fatalf("expected passkey disabled in OIDC-only mode")
+	}
+}

--- a/internal/service/account/member.go
+++ b/internal/service/account/member.go
@@ -17,6 +17,7 @@ var (
 	ErrMemberNotFound   = errors.New("成员不存在")
 	ErrMemberExists     = errors.New("用户名已存在")
 	ErrInvalidRequest   = errors.New("用户名不能为空")
+	ErrPasswordRequired = errors.New("密码不能为空")
 	ErrFounderProtected = errors.New("创始人不可修改或删除")
 	ErrPasskeyNotFound  = errors.New("凭证不存在")
 )
@@ -69,6 +70,9 @@ func (s *Service) MemberCreate(req MemberUpsertRequest) error {
 	}
 	if _, exists := config.Members[req.Username]; exists {
 		return ErrMemberExists
+	}
+	if req.Password == "" && !s.OIDCOnly() {
+		return ErrPasswordRequired
 	}
 
 	home, err := s.homeDirEnsure(req.HomeDirectory, req.Username)

--- a/internal/service/account/passkey.go
+++ b/internal/service/account/passkey.go
@@ -213,6 +213,9 @@ func (s *Service) PasskeyFinishRegistration(c *gin.Context, sessionID string) er
 
 // PasskeyBeginLogin 开始 Passkey 登录，username 为空则使用可发现凭证
 func (s *Service) PasskeyBeginLogin(username string) (*PasskeyBeginData, error) {
+	if s.OIDCOnly() {
+		return nil, fmt.Errorf("仅允许 OIDC 登录")
+	}
 	if !s.PasskeyEnabled() {
 		return nil, fmt.Errorf("Passkey 未启用")
 	}
@@ -248,6 +251,9 @@ func (s *Service) PasskeyBeginLogin(username string) (*PasskeyBeginData, error) 
 
 // PasskeyFinishLogin 完成 Passkey 登录，直接从 c.Request 读取凭证数据
 func (s *Service) PasskeyFinishLogin(c *gin.Context, sessionID string) (*LoginResponse, error) {
+	if s.OIDCOnly() {
+		return nil, fmt.Errorf("仅允许 OIDC 登录")
+	}
 	session := s.passkeyStore.pop(sessionID)
 	if session == nil {
 		return nil, fmt.Errorf("登录会话不存在或已过期")

--- a/internal/service/system/config.go
+++ b/internal/service/system/config.go
@@ -77,6 +77,9 @@ func (s *ConfigService) ConfigAll() *AllConfig {
 
 // ConfigUpdate 一次性更新全部配置（任何 nil 分区将跳过）
 func (s *ConfigService) ConfigUpdate(req AllConfig) error {
+	if err := validateAuthConfig(req); err != nil {
+		return err
+	}
 	if req.Server != nil {
 		oldSecret := ""
 		if config.Server != nil {
@@ -173,4 +176,25 @@ func pickSecret(newVal, oldVal string) string {
 		return oldVal
 	}
 	return newVal
+}
+
+func validateAuthConfig(req AllConfig) error {
+	tha := config.THA
+	if req.THA != nil {
+		tha = config.THANormalize(req.THA)
+	}
+	oidc := config.OIDC
+	if req.OIDC != nil {
+		oidc = config.OIDCNormalize(req.OIDC)
+	}
+	if oidc == nil || !oidc.Only {
+		return nil
+	}
+	if !oidc.Enabled || strings.TrimSpace(oidc.IssuerURL) == "" || strings.TrimSpace(oidc.ClientID) == "" {
+		return fmt.Errorf("仅 OIDC 登录需要先启用 OIDC 并配置 issuerUrl 和 clientId")
+	}
+	if tha != nil && tha.Enabled {
+		return fmt.Errorf("仅 OIDC 登录不能与代理 Header 登录同时启用")
+	}
+	return nil
 }

--- a/internal/service/system/config_test.go
+++ b/internal/service/system/config_test.go
@@ -1,0 +1,53 @@
+package system
+
+import (
+	"testing"
+
+	"isrvd/config"
+)
+
+func withSystemConfig(t *testing.T, tha *config.THAConfig, oidc *config.OIDCConfig) {
+	t.Helper()
+	oldTHA := config.THA
+	oldOIDC := config.OIDC
+	config.THA = tha
+	config.OIDC = oidc
+	t.Cleanup(func() {
+		config.THA = oldTHA
+		config.OIDC = oldOIDC
+	})
+}
+
+func TestValidateAuthConfigRejectsIncompleteOIDCOnly(t *testing.T) {
+	withSystemConfig(t, &config.THAConfig{}, &config.OIDCConfig{})
+
+	err := validateAuthConfig(AllConfig{
+		OIDC: &config.OIDCConfig{Enabled: true, Only: true, IssuerURL: "https://idp.example.com"},
+	})
+	if err == nil {
+		t.Fatalf("expected incomplete OIDC-only config to fail")
+	}
+}
+
+func TestValidateAuthConfigRejectsOIDCOnlyWithHeaderAuth(t *testing.T) {
+	withSystemConfig(t, &config.THAConfig{}, &config.OIDCConfig{})
+
+	err := validateAuthConfig(AllConfig{
+		THA:  &config.THAConfig{Enabled: true, HeaderName: "X-Username"},
+		OIDC: &config.OIDCConfig{Enabled: true, Only: true, IssuerURL: "https://idp.example.com", ClientID: "isrvd"},
+	})
+	if err == nil {
+		t.Fatalf("expected OIDC-only and header auth conflict to fail")
+	}
+}
+
+func TestValidateAuthConfigAcceptsOIDCOnly(t *testing.T) {
+	withSystemConfig(t, &config.THAConfig{}, &config.OIDCConfig{})
+
+	err := validateAuthConfig(AllConfig{
+		OIDC: &config.OIDCConfig{Enabled: true, Only: true, IssuerURL: "https://idp.example.com", ClientID: "isrvd"},
+	})
+	if err != nil {
+		t.Fatalf("validate OIDC-only config: %v", err)
+	}
+}

--- a/webview/src/component/user-menu.vue
+++ b/webview/src/component/user-menu.vue
@@ -21,7 +21,7 @@ class UserMenu extends Vue {
   get themeLabel() { return THEME_META[this.themeMode].label }
 
   // Passkey 入口：功能已启用且具备查看权限时显示
-  get showPasskeyEntry() { return this.portal.passkeyEnabled && this.portal.hasPerm('GET /api/account/passkey/credentials') }
+  get showPasskeyEntry() { return !this.portal.oidcOnly && this.portal.passkeyEnabled && this.portal.hasPerm('GET /api/account/passkey/credentials') }
 
   // ─── 方法 ───
   toggleTheme() {
@@ -60,7 +60,7 @@ export default toNative(UserMenu)
     </button>
 
     <!-- 账户设置 -->
-    <router-link to="/account/password" class="dropdown-item" @click="menuOpen = false">
+    <router-link v-if="!portal.oidcOnly" to="/account/password" class="dropdown-item" @click="menuOpen = false">
       <i class="fas fa-lock"></i>
       账号安全
     </router-link>

--- a/webview/src/service/types/account.ts
+++ b/webview/src/service/types/account.ts
@@ -5,6 +5,7 @@ export interface AuthInfo {
     username?: string
     member?: MemberInfo
     oidcEnabled: boolean
+    oidcOnly: boolean
     // OIDC 登录按钮自定义名称
     oidcBtnLabel?: string
     passkeyEnabled: boolean

--- a/webview/src/service/types/system.ts
+++ b/webview/src/service/types/system.ts
@@ -34,6 +34,7 @@ export interface THAConfig {
 
 export interface OIDCConfig {
     enabled: boolean
+    only: boolean
     issuerUrl: string
     clientId: string
     // 写入时为空表示保留原值（不通过 JSON 返回）

--- a/webview/src/stores/auth.ts
+++ b/webview/src/stores/auth.ts
@@ -13,6 +13,7 @@ export const useAuthStore = defineStore('auth', () => {
     const founder = ref(false)
     const permissions = ref<string[]>([])
     const oidcEnabled = ref(false)
+    const oidcOnly = ref(false)
     const oidcLoginLabel = ref('')
     const passkeyEnabled = ref(false)
 
@@ -60,6 +61,7 @@ export const useAuthStore = defineStore('auth', () => {
 
         // OIDC / Passkey 配置无论登录状态都更新（放在 clearAuth 之后）
         oidcEnabled.value = auth?.oidcEnabled || false
+        oidcOnly.value = auth?.oidcOnly || false
         oidcLoginLabel.value = auth?.oidcBtnLabel || ''
         passkeyEnabled.value = auth?.passkeyEnabled || false
     }
@@ -84,6 +86,7 @@ export const useAuthStore = defineStore('auth', () => {
         founder,
         permissions,
         oidcEnabled,
+        oidcOnly,
         oidcLoginLabel,
         passkeyEnabled,
         // 操作

--- a/webview/src/stores/portal.ts
+++ b/webview/src/stores/portal.ts
@@ -119,6 +119,7 @@ export const usePortalStore = defineStore('portal', () => {
         founder: authRefs.founder,
         permissions: authRefs.permissions,
         oidcEnabled: authRefs.oidcEnabled,
+        oidcOnly: authRefs.oidcOnly,
         oidcLoginLabel: authRefs.oidcLoginLabel,
         passkeyEnabled: authRefs.passkeyEnabled,
         // Auth Store 方法

--- a/webview/src/views/account/login.vue
+++ b/webview/src/views/account/login.vue
@@ -103,7 +103,7 @@ export default toNative(Login)
         </div>
 
         <!-- Form -->
-        <form class="space-y-5" @submit.prevent="handleLogin">
+        <form v-if="!portal.oidcOnly" class="space-y-5" @submit.prevent="handleLogin">
           <div>
             <label for="username" class="form-label">
               用户名
@@ -167,6 +167,13 @@ export default toNative(Login)
             </div>
           </template>
         </form>
+
+        <div v-else class="space-y-4">
+          <button v-if="portal.oidcEnabled" type="button" class="btn btn-indigo w-full" @click="handleOIDCLogin">
+            <i class="fas fa-id-badge mr-2"></i>
+            {{ portal.oidcLoginLabel || '使用 OIDC 登录' }}
+          </button>
+        </div>
       </div>
 
       <!-- Footer -->

--- a/webview/src/views/account/widget/member-edit-modal.vue
+++ b/webview/src/views/account/widget/member-edit-modal.vue
@@ -85,6 +85,10 @@ class MemberEditModal extends Vue {
         return this.isEdit ? '编辑成员' : '新建成员'
     }
 
+    get passwordRequired() {
+        return !this.isEdit && !this.portal.oidcOnly
+    }
+
     // ─── 方法 ───
     async loadRoutes() {
         if (this.routeGroups.length > 0) return
@@ -235,7 +239,7 @@ class MemberEditModal extends Vue {
 
     async handleConfirm() {
         if (!this.formData.username?.trim()) return
-        if (!this.isEdit && !this.formData.password?.trim()) {
+        if (this.passwordRequired && !this.formData.password?.trim()) {
             this.portal.showNotification('warning', '请填写登录密码')
             return
         }
@@ -271,10 +275,12 @@ export default toNative(MemberEditModal)
       <div>
         <label class="form-label">
           密码
-          <span v-if="!isEdit" class="text-red-500">*</span>
-          <span v-else class="text-slate-400 font-normal">(留空则保持不变)</span>
+          <span v-if="passwordRequired" class="text-red-500">*</span>
+          <span v-else-if="isEdit" class="text-slate-400 font-normal">(留空则保持不变)</span>
+          <span v-else class="text-slate-400 font-normal">(可选)</span>
         </label>
-        <input v-model="formData.password" type="password" :placeholder="isEdit ? '留空则保持不变' : '请输入登录密码'" class="input" autocomplete="new-password" />
+        <input v-model="formData.password" type="password" :placeholder="passwordRequired ? '请输入登录密码' : '留空则保持不变'" class="input" autocomplete="new-password" />
+        <p v-if="portal.oidcOnly && !isEdit" class="mt-1 text-xs text-slate-400">仅 OIDC 登录模式下可留空，成员用于匹配 OIDC 用户和授权。</p>
       </div>
       <div>
         <label class="form-label">家目录 <span class="text-slate-400 font-normal">(可选)</span></label>

--- a/webview/src/views/system/config.vue
+++ b/webview/src/views/system/config.vue
@@ -24,7 +24,7 @@ class Config extends Vue {
   allowedOriginsText = ''
   tha: THAConfig = { enabled: false, headerName: '', trustedCIDRs: [] }
   thaTrustedCIDRsText = ''
-  oidc: OIDCConfig = { enabled: false, issuerUrl: '', clientId: '', redirectUrl: '', usernameClaim: 'sub', scopes: ['openid', 'profile', 'email'], loginLabel: '' }
+  oidc: OIDCConfig = { enabled: false, only: false, issuerUrl: '', clientId: '', redirectUrl: '', usernameClaim: 'sub', scopes: ['openid', 'profile', 'email'], loginLabel: '' }
   oidcScopes = 'openid profile email'
   passkey: PasskeyConfig = { enabled: false, rpName: '', rpId: '', rpOrigins: [], timeout: 60000 }
   passkeyOriginsText = ''
@@ -62,7 +62,7 @@ class Config extends Vue {
       this.allowedOriginsText = (this.server.allowedOrigins || []).join('\n')
       this.tha = { ...payload.tha }
       this.thaTrustedCIDRsText = (this.tha.trustedCIDRs || []).join('\n')
-      this.oidc = { ...(payload.oidc || { enabled: false, issuerUrl: '', clientId: '', redirectUrl: '', usernameClaim: 'sub', scopes: ['openid', 'profile', 'email'], loginLabel: '' }) }
+      this.oidc = payload.oidc ? { ...payload.oidc, only: payload.oidc.only || false } : { enabled: false, only: false, issuerUrl: '', clientId: '', redirectUrl: '', usernameClaim: 'sub', scopes: ['openid', 'profile', 'email'], loginLabel: '' }
       this.oidcScopes = (this.oidc.scopes || []).join(' ')
       this.passkey = { ...(payload.passkey || { enabled: false, rpName: '', rpId: '', rpOrigins: [], timeout: 60000 }) }
       this.passkeyOriginsText = (this.passkey.rpOrigins || []).join('\n')
@@ -292,6 +292,7 @@ export default toNative(Config)
               </div>
             </div>
             <ToggleCard v-model="oidc.enabled" label="启用 OIDC 登录" desc="使用 OpenID Connect 进行单点登录" />
+            <ToggleCard v-model="oidc.only" label="仅允许 OIDC 登录" desc="开启后禁用账号密码和 Passkey 登录入口，OIDC 登录后仍使用系统权限和 JWT" />
             <div>
               <label class="form-label">颁发者地址</label>
               <input v-model="oidc.issuerUrl" type="text" placeholder="请输入颁发者地址" class="input" />


### PR DESCRIPTION
## 变更概述

本次变更在现有 OIDC 登录能力基础上新增 `oidc.only` 配置，用于支持“仅允许 OIDC 交互式登录”的部署模式。

开启后：

- 禁用账号密码登录接口，避免继续使用本地密码作为交互式登录入口。
- 禁用 Passkey 登录入口，避免出现多个交互式认证方式并存。
- OIDC 登录成功后仍签发系统 JWT，继续复用现有成员、权限和会话模型。
- API Token 创建和使用保持兼容，便于脚本与自动化流程继续工作。

## 主要改动

- 后端配置新增 `oidc.only` 字段，并在系统配置保存时校验：
  - 必须同时启用 OIDC。
  - 必须配置 `issuerUrl` 和 `clientId`。
  - 不能与代理 Header 登录同时启用。
- 账号服务在 OIDC-only 模式下拒绝：
  - `POST /api/account/login`
  - `POST /api/account/passkey/login/begin`
  - `POST /api/account/passkey/login/finish`
- `/api/overview/bootstrap` 的认证信息新增 `oidcOnly`，前端可在未登录状态下决定登录页展示。
- 前端登录页在 OIDC-only 模式下只显示 OIDC 登录按钮。
- 用户菜单在 OIDC-only 模式下隐藏账号安全和 Passkey 入口，保留 API Key 入口。
- 成员创建在 OIDC-only 模式下允许密码留空，成员仍用于匹配 OIDC 用户、设置家目录和授权。
- 同步更新系统配置与账户管理文档。
- 补充服务层测试覆盖 OIDC-only 登录拒绝和配置校验。

## 影响范围

- 默认行为不变：`oidc.only` 缺省为 `false`。
- 已有 OIDC 登录流程不变：仍使用 Authorization Code Flow，仍要求 OIDC claim 匹配本地 `members.username`。
- 已签发的 JWT/API Token 校验逻辑不变。
- 不引入自动创建成员逻辑，避免权限默认值和家目录策略扩散。

## 验证

- `go test ./...`
- `cd webview && npm run lint`
- `cd webview && npm run format:check`
- `cd webview && python3 scripts/review-style.py`
- `git diff --check`

说明：`format:check` 退出码为 0，但仍提示仓库中 16 个既有文件需要格式化；这些文件不属于本次改动范围。
