### PR TITLE
fix: 为 Swarm 服务传递仓库认证

### DIFF
--- a/docs/references/swarm/services.md
+++ b/docs/references/swarm/services.md
@@ -1,5 +1,7 @@
 # Swarm 服务 API
 
+创建服务、扩缩容和强制更新会自动使用 Docker 仓库配置中的认证信息：当服务镜像的 registry host 匹配 `docker.registries[].url` 时，后端会以 Swarm 原生的 registry auth 方式提交，并启用 registry 查询以解析镜像 tag/digest，便于 Worker 节点拉取私有仓库镜像。
+
 ## 列出服务
 
 ```bash
@@ -53,11 +55,15 @@ isrvd_post "/swarm/service" '{
 | labels | object | | 标签 |
 | constraints | string[] | | 放置约束；指定运行节点时使用 `node.hostname == <NODE_HOSTNAME>` |
 
+说明：创建时会按 `image` 自动匹配已配置的 Docker 仓库认证，并请求 registry 解析镜像 tag/digest。
+
 ## 扩缩容
 
 ```bash
 isrvd_post "/swarm/service/<SVC_ID>/action" '{"action":"scale","replicas":<N>}'
 ```
+
+说明：扩缩容会沿用服务当前镜像自动匹配仓库认证，并请求 registry 解析镜像 tag/digest。
 
 ## 删除服务
 
@@ -70,6 +76,8 @@ isrvd_post "/swarm/service/<SVC_ID>/action" '{"action":"remove"}'
 ```bash
 isrvd_post "/swarm/service/<SVC_ID>/action" '{"action":"force-update"}'
 ```
+
+说明：强制更新会沿用服务当前镜像自动匹配仓库认证，并请求 registry 解析镜像 tag/digest。
 
 ## 服务日志
 

--- a/internal/registry/docker.go
+++ b/internal/registry/docker.go
@@ -39,7 +39,7 @@ func initDocker() error {
 	}
 
 	DockerService = svc
-	SwarmService = swarm.NewSwarmService(svc.Client())
+	SwarmService = swarm.NewSwarmService(svc.Client(), svc.RegistryAuth)
 
 	return nil
 }

--- a/pkgs/docker/registry.go
+++ b/pkgs/docker/registry.go
@@ -155,6 +155,11 @@ func (s *DockerService) ImagePull(ctx context.Context, imageName, registryURL, n
 	return lastMsg, imageRef, nil
 }
 
+// RegistryAuth 根据镜像引用自动匹配已配置的 registry 认证信息。
+func (s *DockerService) RegistryAuth(imageRef string) string {
+	return s.getRegistryAuth(imageRef)
+}
+
 // getRegistryAuth 根据镜像引用自动匹配已配置的 registry 认证信息
 // imageRef 可以是完整镜像引用（如 "csighub.tencentyun.com/ns/app:v1"）或仓库 URL
 // 匹配规则：提取 imageRef 的 host 部分，与已配置仓库的 host 对比

--- a/pkgs/swarm/client.go
+++ b/pkgs/swarm/client.go
@@ -11,12 +11,13 @@ import (
 
 // SwarmService Swarm 业务逻辑服务
 type SwarmService struct {
-	client *client.Client
+	client       *client.Client
+	registryAuth func(imageRef string) string
 }
 
 // NewSwarmService 创建 Swarm 服务
-func NewSwarmService(dockerClient *client.Client) *SwarmService {
-	return &SwarmService{client: dockerClient}
+func NewSwarmService(dockerClient *client.Client, registryAuth func(imageRef string) string) *SwarmService {
+	return &SwarmService{client: dockerClient, registryAuth: registryAuth}
 }
 
 // Client 获取 Docker 客户端

--- a/pkgs/swarm/service.go
+++ b/pkgs/swarm/service.go
@@ -47,9 +47,13 @@ func (s *SwarmService) ServiceAction(ctx context.Context, id, action string, rep
 			return fmt.Errorf("仅 replicated 模式服务支持 scale")
 		}
 		svc.Spec.Mode.Replicated.Replicas = replicas
-		if _, err := s.client.ServiceUpdate(ctx, id, svc.Version, svc.Spec, dockerSwarm.ServiceUpdateOptions{}); err != nil {
+		resp, err := s.client.ServiceUpdate(ctx, id, svc.Version, svc.Spec, s.serviceUpdateOptions(svc.Spec))
+		if err != nil {
 			logman.Error("ServiceScale failed", "id", id, "replicas", *replicas, "error", err)
 			return err
+		}
+		for _, warning := range resp.Warnings {
+			logman.Warn("ServiceScale warning", "id", id, "warning", warning)
 		}
 		return nil
 	}
@@ -63,10 +67,13 @@ func (s *SwarmService) ServiceAction(ctx context.Context, id, action string, rep
 
 // ServiceCreate 创建服务，直接接收 Docker SDK 原始 ServiceSpec。
 func (s *SwarmService) ServiceCreate(ctx context.Context, spec dockerSwarm.ServiceSpec) (string, error) {
-	resp, err := s.client.ServiceCreate(ctx, spec, dockerSwarm.ServiceCreateOptions{})
+	resp, err := s.client.ServiceCreate(ctx, spec, s.serviceCreateOptions(spec))
 	if err != nil {
 		logman.Error("ServiceCreate failed", "error", err)
 		return "", err
+	}
+	for _, warning := range resp.Warnings {
+		logman.Warn("ServiceCreate warning", "service", spec.Name, "warning", warning)
 	}
 	return resp.ID, nil
 }
@@ -81,9 +88,13 @@ func (s *SwarmService) ServiceForceUpdate(ctx context.Context, id string) error 
 
 	svc.Spec.TaskTemplate.ForceUpdate++
 
-	if _, err := s.client.ServiceUpdate(ctx, id, svc.Version, svc.Spec, dockerSwarm.ServiceUpdateOptions{}); err != nil {
+	resp, err := s.client.ServiceUpdate(ctx, id, svc.Version, svc.Spec, s.serviceUpdateOptions(svc.Spec))
+	if err != nil {
 		logman.Error("ServiceForceUpdate failed", "error", err)
 		return err
+	}
+	for _, warning := range resp.Warnings {
+		logman.Warn("ServiceForceUpdate warning", "id", id, "warning", warning)
 	}
 	return nil
 }
@@ -218,4 +229,40 @@ func (s *SwarmService) ServiceInspectRaw(ctx context.Context, id string) (docker
 	return svc, nil
 }
 
+// ─── 辅助函数 ───
 
+func (s *SwarmService) serviceCreateOptions(spec dockerSwarm.ServiceSpec) dockerSwarm.ServiceCreateOptions {
+	return dockerSwarm.ServiceCreateOptions{
+		EncodedRegistryAuth: s.serviceRegistryAuth(spec),
+		QueryRegistry:       true,
+	}
+}
+
+func (s *SwarmService) serviceUpdateOptions(spec dockerSwarm.ServiceSpec) dockerSwarm.ServiceUpdateOptions {
+	return dockerSwarm.ServiceUpdateOptions{
+		EncodedRegistryAuth: s.serviceRegistryAuth(spec),
+		RegistryAuthFrom:    dockerSwarm.RegistryAuthFromPreviousSpec,
+		QueryRegistry:       true,
+	}
+}
+
+func (s *SwarmService) serviceRegistryAuth(spec dockerSwarm.ServiceSpec) string {
+	if s.registryAuth == nil {
+		return ""
+	}
+	imageRef := serviceImageRef(spec)
+	if imageRef == "" {
+		return ""
+	}
+	return s.registryAuth(imageRef)
+}
+
+func serviceImageRef(spec dockerSwarm.ServiceSpec) string {
+	if spec.TaskTemplate.ContainerSpec != nil {
+		return spec.TaskTemplate.ContainerSpec.Image
+	}
+	if spec.TaskTemplate.PluginSpec != nil {
+		return spec.TaskTemplate.PluginSpec.Remote
+	}
+	return ""
+}


### PR DESCRIPTION
## 变更说明

- Swarm 创建服务时启用 registry 查询，并按服务镜像自动匹配 Docker 仓库认证。
- Swarm 扩缩容和强制更新时同样携带 registry auth，便于 Worker 节点拉取私有仓库镜像。
- 复用现有 Docker 仓库配置，不新增 Swarm 专属账号配置。
- 更新 Swarm 服务 API 文档，说明创建、扩缩容、强制更新时的认证和镜像解析行为。

## 背景

当前 Swarm 服务创建和更新没有传递 registry auth。对于私有镜像，如果 Worker 节点没有单独登录仓库，任务调度到 Worker 后可能因为无权限拉取镜像而失败。

## 验证

- go test ./...
