### PR TITLE
Skill 适配完整 API Root 与自定义认证 Header

### DIFF
--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -9,10 +9,12 @@ description: 通过 isrvd API 进行容器部署、服务管理、镜像操作�
 
 推荐按 **Python → Node.js** 的顺序选择脚本；仅当 Python 和 Node.js 都不可用时，才使用 Bash 版兜底。三者共用 `~/.config/isrvd/profile.json`。
 
+脚本的 URL 参数必须填写从域名到 API 根路径的完整地址，例如 `https://gateway.example.invalid/isrvd/api` 或 `https://gateway.example.invalid/isrvd/api/automation`。不要只填写域名；业务路径仍使用 `/docker/containers` 这类以 `/` 开头的相对路径。默认认证方式是 `Authorization: Bearer <API_TOKEN>`；如果前置网关要求使用其他请求头，可设置 `ISRVD_AUTH_HEADER`，例如 `ISRVD_AUTH_HEADER=token` 会发送 `token: <API_TOKEN>`。
+
 **首选：Python 标准库版**（无 `curl`/`jq` 依赖）
 
 ```bash
-python3 ./scripts/api.py token "$ISRVD_APIURL" "$ISRVD_APITOKEN"
+python3 ./scripts/api.py token "$API_ROOT" "$TOKEN"
 python3 ./scripts/api.py get "/docker/containers"
 python3 ./scripts/api.py post "/docker/container" '{"image":"...","name":"..."}'
 ```
@@ -20,7 +22,7 @@ python3 ./scripts/api.py post "/docker/container" '{"image":"...","name":"..."}'
 **备选：Node.js 内置库版**（无 `curl`/`jq` 依赖）
 
 ```bash
-node ./scripts/api.js token "$ISRVD_APIURL" "$ISRVD_APITOKEN"
+node ./scripts/api.js token "$API_ROOT" "$TOKEN"
 node ./scripts/api.js get "/docker/containers"
 node ./scripts/api.js post "/docker/container" '{"image":"...","name":"..."}'
 ```
@@ -31,9 +33,9 @@ node ./scripts/api.js post "/docker/container" '{"image":"...","name":"..."}'
 source ./scripts/api.sh
 
 # 认证方式（优先使用环境变量，自动保存到 ~/.config/isrvd/profile.json）
-isrvd_token "$ISRVD_APIURL" "$ISRVD_APITOKEN"
+isrvd_token "$API_ROOT" "$TOKEN"
 # 或
-isrvd_login "$ISRVD_APIURL" "$ISRVD_USERNAME" "$ISRVD_PASSWORD"
+isrvd_login "$API_ROOT" "$ISRVD_USERNAME" "$ISRVD_PASSWORD"
 
 isrvd_get "/docker/containers"
 isrvd_post "/docker/container" '{"image":"...","name":"..."}'

--- a/docs/scripts/api.js
+++ b/docs/scripts/api.js
@@ -21,30 +21,48 @@ function green(text) { console.error(color('0;32', text)); }
 function yellow(text) { console.error(color('0;33', text)); }
 function blue(text) { console.error(color('0;34', text)); }
 
+function normalizeApiRoot(baseUrl) {
+  return baseUrl.replace(/\/+$/, '');
+}
+
+function apiUrl(baseUrl, apiPath) {
+  return `${normalizeApiRoot(baseUrl)}/${apiPath.replace(/^\/+/, '')}`;
+}
+
+function authHeaders(token, authHeader) {
+  if (!token) return {};
+  return authHeader.toLowerCase() === 'authorization'
+    ? { Authorization: `Bearer ${token}` }
+    : { [authHeader]: token };
+}
+
 function loadConfig() {
   const cfg = {
-    base_url: (process.env.ISRVD_BASE_URL || '').replace(/\/$/, ''),
+    base_url: (process.env.ISRVD_BASE_URL || '').replace(/\/+$/, ''),
     token: process.env.ISRVD_TOKEN || '',
     username: process.env.ISRVD_USERNAME || '',
+    auth_header: process.env.ISRVD_AUTH_HEADER || '',
   };
-  if (cfg.base_url && cfg.token) return cfg;
   if (fs.existsSync(configFile)) {
     try {
       const saved = JSON.parse(fs.readFileSync(configFile, 'utf8'));
-      cfg.base_url = cfg.base_url || String(saved.base_url || '').replace(/\/$/, '');
+      cfg.base_url = cfg.base_url || String(saved.base_url || '').replace(/\/+$/, '');
       cfg.token = cfg.token || String(saved.token || '');
       cfg.username = cfg.username || String(saved.username || '');
+      cfg.auth_header = cfg.auth_header || String(saved.auth_header || '');
     } catch (_) {}
   }
+  cfg.auth_header = cfg.auth_header || 'Authorization';
   return cfg;
 }
 
 function saveConfig(cfg) {
   fs.mkdirSync(configDir, { recursive: true });
   fs.writeFileSync(configFile, JSON.stringify({
-    base_url: (cfg.base_url || '').replace(/\/$/, ''),
+    base_url: cfg.base_url ? normalizeApiRoot(cfg.base_url) : '',
     token: cfg.token || '',
     username: cfg.username || '',
+    auth_header: cfg.auth_header || 'Authorization',
   }, null, 2) + '\n', 'utf8');
   fs.chmodSync(configFile, 0o600);
 }
@@ -60,12 +78,11 @@ function requireAuth() {
   return cfg;
 }
 
-function httpRequest(method, urlText, token = '', body = undefined, headers = {}) {
+function httpRequest(method, urlText, token = '', body = undefined, headers = {}, authHeader = 'Authorization') {
   return new Promise((resolve, reject) => {
     const url = new URL(urlText);
     const data = body === undefined ? null : Buffer.from(JSON.stringify(body));
-    const reqHeaders = { ...headers };
-    if (token) reqHeaders.Authorization = `Bearer ${token}`;
+    const reqHeaders = { ...headers, ...authHeaders(token, authHeader) };
     if (data) {
       reqHeaders['Content-Type'] = 'application/json';
       reqHeaders['Content-Length'] = String(data.length);
@@ -91,7 +108,7 @@ function httpRequest(method, urlText, token = '', body = undefined, headers = {}
   });
 }
 
-function multipartRequest(urlText, token, fileField, filePath, fields) {
+function multipartRequest(urlText, token, fileField, filePath, fields, authHeader = 'Authorization') {
   return new Promise((resolve, reject) => {
     const boundary = `isrvd-${crypto.randomUUID()}`;
     const chunks = [];
@@ -110,7 +127,7 @@ function multipartRequest(urlText, token, fileField, filePath, fields) {
     const req = lib.request(url, {
       method: 'POST',
       headers: {
-        Authorization: `Bearer ${token}`,
+        ...authHeaders(token, authHeader),
         'Content-Type': `multipart/form-data; boundary=${boundary}`,
         'Content-Length': String(data.length),
       },
@@ -175,7 +192,7 @@ function printCompactJsonOrRaw(raw) {
 async function apiCall(method, apiPath, bodyText = '', selector = '') {
   const cfg = requireAuth();
   const body = bodyText ? JSON.parse(bodyText) : undefined;
-  const data = await httpRequest(method, `${cfg.base_url}/api${apiPath}`, cfg.token, body);
+  const data = await httpRequest(method, apiUrl(cfg.base_url, apiPath), cfg.token, body, {}, cfg.auth_header);
   printResult(applyFilter(payloadOf(data), selector));
 }
 
@@ -198,7 +215,7 @@ function usage() {
     api.js upload <path> <field> <file> [k=v...]
 
   Examples:
-    api.js token "$ISRVD_APIURL" "$ISRVD_APITOKEN"
+    api.js token "$API_ROOT" "$TOKEN"
     api.js get /docker/containers
     api.js post /docker/container '{"image":"...","name":"..."}'
 `);
@@ -210,29 +227,29 @@ async function main() {
     switch (command) {
       case 'login': {
         const [base, username, password, totp] = args;
-        if (!base || !username || !password) throw new Error('usage: api.js login <base_url> <username> <password> [totpCode]');
-        const baseUrl = base.replace(/\/$/, '');
+        if (!base || !username || !password) throw new Error('usage: api.js login <api_root> <username> <password> [totpCode]');
+        const baseUrl = normalizeApiRoot(base);
         const body = { username, password };
         if (totp) body.totpCode = totp;
         blue(`→ 登录 ${baseUrl} ...`);
-        const data = await httpRequest('POST', `${baseUrl}/api/account/login`, '', body);
+        const data = await httpRequest('POST', apiUrl(baseUrl, '/account/login'), '', body, {}, process.env.ISRVD_AUTH_HEADER || 'Authorization');
         if (!data || data.success !== true) throw new Error(`登录失败: ${data && data.message ? data.message : '未知错误'}`);
-        if (data.payload && data.payload.twoFactorRequired) throw new Error('该账号已启用 TOTP 二次验证。请使用: api.js login <base_url> <username> <password> <totpCode>');
+        if (data.payload && data.payload.twoFactorRequired) throw new Error('该账号已启用 TOTP 二次验证。请使用: api.js login <api_root> <username> <password> <totpCode>');
         const token = data.payload && data.payload.token;
         if (!token) throw new Error('登录失败: 响应中缺少 token');
-        saveConfig({ base_url: baseUrl, token, username });
+        saveConfig({ base_url: baseUrl, token, username, auth_header: process.env.ISRVD_AUTH_HEADER || 'Authorization' });
         green(`✓ 登录成功，已保存到 ${configFile}`);
         break;
       }
       case 'token': {
         const [base, token] = args;
-        if (!base || !token) throw new Error('usage: api.js token <base_url> <token>');
-        const baseUrl = base.replace(/\/$/, '');
+        if (!base || !token) throw new Error('usage: api.js token <api_root> <token>');
+        const baseUrl = normalizeApiRoot(base);
         blue('→ 验证 token ...');
-        const data = await httpRequest('GET', `${baseUrl}/api/overview/bootstrap`, token);
+        const data = await httpRequest('GET', apiUrl(baseUrl, '/overview/bootstrap'), token, undefined, {}, process.env.ISRVD_AUTH_HEADER || 'Authorization');
         if (!data || data.success !== true) throw new Error(`token 无效: ${data && data.message ? data.message : '未知错误'}`);
         const username = (data.payload && data.payload.auth && data.payload.auth.username) || 'unknown';
-        saveConfig({ base_url: baseUrl, token, username });
+        saveConfig({ base_url: baseUrl, token, username, auth_header: process.env.ISRVD_AUTH_HEADER || 'Authorization' });
         green(`✓ token 有效 (用户: ${username})，已保存到 ${configFile}`);
         break;
       }
@@ -245,7 +262,7 @@ async function main() {
         const [apiPath, field, file, ...fields] = args;
         if (!apiPath || !field || !file) throw new Error('usage: api.js upload <path> <file_field> <file_path> [key=value ...]');
         const cfg = requireAuth();
-        printResult(await multipartRequest(`${cfg.base_url}/api${apiPath}`, cfg.token, field, file, fields));
+        printResult(await multipartRequest(apiUrl(cfg.base_url, apiPath), cfg.token, field, file, fields, cfg.auth_header));
         break;
       }
       case 'whoami': await apiCall('GET', '/overview/bootstrap'); break;

--- a/docs/scripts/api.py
+++ b/docs/scripts/api.py
@@ -41,50 +41,67 @@ def blue(text: str) -> None:
     print(color('0;34', text), file=sys.stderr)
 
 
+def normalize_api_root(base_url: str) -> str:
+    return base_url.rstrip('/')
+
+
+def api_url(base_url: str, path: str) -> str:
+    return normalize_api_root(base_url) + '/' + path.lstrip('/')
+
+
 def load_config() -> dict[str, str]:
     cfg = {
         'base_url': os.environ.get('ISRVD_BASE_URL', '').rstrip('/'),
         'token': os.environ.get('ISRVD_TOKEN', ''),
         'username': os.environ.get('ISRVD_USERNAME', ''),
+        'auth_header': os.environ.get('ISRVD_AUTH_HEADER', ''),
     }
-    if cfg['base_url'] and cfg['token']:
-        return cfg
     if CONFIG_FILE.exists():
         try:
             saved = json.loads(CONFIG_FILE.read_text(encoding='utf-8'))
             cfg['base_url'] = cfg['base_url'] or str(saved.get('base_url') or '').rstrip('/')
             cfg['token'] = cfg['token'] or str(saved.get('token') or '')
             cfg['username'] = cfg['username'] or str(saved.get('username') or '')
+            cfg['auth_header'] = cfg['auth_header'] or str(saved.get('auth_header') or '')
         except json.JSONDecodeError:
             pass
+    cfg['auth_header'] = cfg['auth_header'] or 'Authorization'
     return cfg
 
 
 def save_config(cfg: dict[str, str]) -> None:
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
     CONFIG_FILE.write_text(json.dumps({
-        'base_url': cfg.get('base_url', '').rstrip('/'),
+        'base_url': normalize_api_root(cfg.get('base_url', '')) if cfg.get('base_url') else '',
         'token': cfg.get('token', ''),
         'username': cfg.get('username', ''),
+        'auth_header': cfg.get('auth_header', 'Authorization'),
     }, ensure_ascii=False, indent=2) + '\n', encoding='utf-8')
     CONFIG_FILE.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+
+def auth_headers(token: str, auth_header: str) -> dict[str, str]:
+    if not token:
+        return {}
+    if auth_header.lower() == 'authorization':
+        return {'Authorization': f'Bearer {token}'}
+    return {auth_header: token}
 
 
 def require_auth() -> dict[str, str]:
     cfg = load_config()
     if not cfg.get('base_url') or not cfg.get('token'):
         red('✗ 未认证。请先执行:')
-        red('  api.py login <base_url> <username> <password> [totpCode]')
-        red('  api.py token <base_url> <token>')
+        red('  api.py login <api_root> <username> <password> [totpCode]')
+        red('  api.py token <api_root> <token>')
         raise SystemExit(1)
     return cfg
 
 
-def request_json(method: str, url: str, token: str = '', body: Any = None, headers: dict[str, str] | None = None) -> Any:
+def request_json(method: str, url: str, token: str = '', body: Any = None, headers: dict[str, str] | None = None, auth_header: str = 'Authorization') -> Any:
     data = None
     req_headers = dict(headers or {})
-    if token:
-        req_headers['Authorization'] = f'Bearer {token}'
+    req_headers.update(auth_headers(token, auth_header))
     if body is not None:
         data = json.dumps(body, ensure_ascii=False, separators=(',', ':')).encode('utf-8')
         req_headers['Content-Type'] = 'application/json'
@@ -108,7 +125,7 @@ def request_json(method: str, url: str, token: str = '', body: Any = None, heade
         return raw
 
 
-def request_multipart(url: str, token: str, file_field: str, file_path: str, fields: list[str]) -> Any:
+def request_multipart(url: str, token: str, file_field: str, file_path: str, fields: list[str], auth_header: str = 'Authorization') -> Any:
     path = Path(file_path)
     boundary = f'isrvd-{uuid.uuid4().hex}'
     parts: list[bytes] = []
@@ -124,7 +141,7 @@ def request_multipart(url: str, token: str, file_field: str, file_path: str, fie
     parts.append(f'\r\n--{boundary}--\r\n'.encode())
     data = b''.join(parts)
     req = request.Request(url, data=data, method='POST', headers={
-        'Authorization': f'Bearer {token}',
+        **auth_headers(token, auth_header),
         'Content-Type': f'multipart/form-data; boundary={boundary}',
         'Content-Length': str(len(data)),
     })
@@ -199,48 +216,48 @@ def print_compact_json_or_raw(raw: str) -> None:
 def api_call(method: str, path: str, body_text: str = '', selector: str = '') -> None:
     cfg = require_auth()
     body = json.loads(body_text) if body_text else None
-    url = cfg['base_url'] + '/api' + path
-    data = request_json(method, url, cfg['token'], body)
+    url = api_url(cfg['base_url'], path)
+    data = request_json(method, url, cfg['token'], body, auth_header=cfg['auth_header'])
     print_result(apply_filter(payload_of(data), selector))
 
 
 def cmd_login(args: argparse.Namespace) -> None:
-    base_url = args.base_url.rstrip('/')
+    base_url = normalize_api_root(args.base_url)
     body = {'username': args.username, 'password': args.password}
     if args.totp_code:
         body['totpCode'] = args.totp_code
     blue(f'→ 登录 {base_url} ...')
-    data = request_json('POST', base_url + '/api/account/login', body=body)
+    data = request_json('POST', api_url(base_url, '/account/login'), body=body, auth_header=os.environ.get('ISRVD_AUTH_HEADER', 'Authorization'))
     if not isinstance(data, dict) or data.get('success') is not True:
         red(f'✗ 登录失败: {data.get("message", "未知错误") if isinstance(data, dict) else data}')
         raise SystemExit(1)
     payload = data.get('payload') or {}
     if payload.get('twoFactorRequired'):
-        red('✗ 该账号已启用 TOTP 二次验证。请使用: api.py login <base_url> <username> <password> <totpCode>')
+        red('✗ 该账号已启用 TOTP 二次验证。请使用: api.py login <api_root> <username> <password> <totpCode>')
         raise SystemExit(1)
     token = payload.get('token') or ''
     if not token:
         red('✗ 登录失败: 响应中缺少 token')
         raise SystemExit(1)
-    save_config({'base_url': base_url, 'token': token, 'username': args.username})
+    save_config({'base_url': base_url, 'token': token, 'username': args.username, 'auth_header': os.environ.get('ISRVD_AUTH_HEADER', 'Authorization')})
     green(f'✓ 登录成功，已保存到 {CONFIG_FILE}')
 
 
 def cmd_token(args: argparse.Namespace) -> None:
-    base_url = args.base_url.rstrip('/')
+    base_url = normalize_api_root(args.base_url)
     blue('→ 验证 token ...')
-    data = request_json('GET', base_url + '/api/overview/bootstrap', args.token)
+    data = request_json('GET', api_url(base_url, '/overview/bootstrap'), args.token, auth_header=os.environ.get('ISRVD_AUTH_HEADER', 'Authorization'))
     if not isinstance(data, dict) or data.get('success') is not True:
         red(f'✗ token 无效: {data.get("message", "未知错误") if isinstance(data, dict) else data}')
         raise SystemExit(1)
     username = str((data.get('payload') or {}).get('auth', {}).get('username') or 'unknown')
-    save_config({'base_url': base_url, 'token': args.token, 'username': username})
+    save_config({'base_url': base_url, 'token': args.token, 'username': username, 'auth_header': os.environ.get('ISRVD_AUTH_HEADER', 'Authorization')})
     green(f'✓ token 有效 (用户: {username})，已保存到 {CONFIG_FILE}')
 
 
 def cmd_upload(args: argparse.Namespace) -> None:
     cfg = require_auth()
-    data = request_multipart(cfg['base_url'] + '/api' + args.path, cfg['token'], args.file_field, args.file_path, args.fields)
+    data = request_multipart(api_url(cfg['base_url'], args.path), cfg['token'], args.file_field, args.file_path, args.fields, cfg['auth_header'])
     print_result(data)
 
 
@@ -266,13 +283,13 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description='isrvd API Harness (Python stdlib edition)')
     sub = parser.add_subparsers(dest='command', required=True)
     p = sub.add_parser('login')
-    p.add_argument('base_url')
+    p.add_argument('base_url', metavar='api_root')
     p.add_argument('username')
     p.add_argument('password')
     p.add_argument('totp_code', nargs='?')
     p.set_defaults(func=cmd_login)
     p = sub.add_parser('token')
-    p.add_argument('base_url')
+    p.add_argument('base_url', metavar='api_root')
     p.add_argument('token')
     p.set_defaults(func=cmd_token)
     for name, method in [('get', 'GET'), ('delete', 'DELETE')]:

--- a/docs/scripts/api.sh
+++ b/docs/scripts/api.sh
@@ -10,6 +10,7 @@ ISRVD_CONFIG_FILE="$ISRVD_CONFIG_DIR/profile.json"
 ISRVD_BASE_URL="${ISRVD_BASE_URL:-}"
 ISRVD_TOKEN="${ISRVD_TOKEN:-}"
 ISRVD_USERNAME="${ISRVD_USERNAME:-}"
+ISRVD_AUTH_HEADER="${ISRVD_AUTH_HEADER:-}"
 
 _red()    { printf '\033[0;31m%s\033[0m\n' "$*"; }
 _green()  { printf '\033[0;32m%s\033[0m\n' "$*"; }
@@ -25,40 +26,55 @@ _isrvd_save_config() {
     --arg url "$ISRVD_BASE_URL" \
     --arg token "$ISRVD_TOKEN" \
     --arg user "$ISRVD_USERNAME" \
-    '{base_url: $url, token: $token, username: $user}' > "$ISRVD_CONFIG_FILE"
+    --arg auth_header "${ISRVD_AUTH_HEADER:-Authorization}" \
+    '{base_url: $url, token: $token, username: $user, auth_header: $auth_header}' > "$ISRVD_CONFIG_FILE"
   chmod 600 "$ISRVD_CONFIG_FILE"
 }
 
 _isrvd_load_config() {
-  # 环境变量优先
-  if [ -n "$ISRVD_BASE_URL" ] && [ -n "$ISRVD_TOKEN" ]; then
-    return 0
-  fi
-
+  # 即使 URL 和 token 来自环境变量，也要从 profile 补齐未设置的认证头等字段。
   if [ -f "$ISRVD_CONFIG_FILE" ]; then
     ISRVD_BASE_URL="${ISRVD_BASE_URL:-$(jq -r '.base_url // empty' "$ISRVD_CONFIG_FILE")}"
     ISRVD_TOKEN="${ISRVD_TOKEN:-$(jq -r '.token // empty' "$ISRVD_CONFIG_FILE")}"
     ISRVD_USERNAME="${ISRVD_USERNAME:-$(jq -r '.username // empty' "$ISRVD_CONFIG_FILE")}"
+    ISRVD_AUTH_HEADER="${ISRVD_AUTH_HEADER:-$(jq -r '.auth_header // empty' "$ISRVD_CONFIG_FILE")}"
     return 0
   fi
 
   return 1
 }
 
+_isrvd_api_root() {
+  local root="${1%/}"
+  while [ "${root%/}" != "$root" ]; do root="${root%/}"; done
+  printf '%s' "$root"
+}
+
+_isrvd_api_url() {
+  local root
+  root=$(_isrvd_api_root "$ISRVD_BASE_URL")
+  printf '%s/%s' "$root" "${1#/}"
+}
+
 _isrvd_auth_header() {
-  printf 'Authorization: Bearer %s' "$ISRVD_TOKEN"
+  local header="${ISRVD_AUTH_HEADER:-Authorization}"
+  if [ "$(printf '%s' "$header" | tr '[:upper:]' '[:lower:]')" = "authorization" ]; then
+    printf 'Authorization: Bearer %s' "$ISRVD_TOKEN"
+  else
+    printf '%s: %s' "$header" "$ISRVD_TOKEN"
+  fi
 }
 
 # ---------------------------------------------------------------------------
 # isrvd_login — 用账号密码登录，token 保存到配置文件
 # ---------------------------------------------------------------------------
 isrvd_login() {
-  local base_url="${1:?用法: isrvd_login <base_url> <username> <password> [totpCode]}"
+  local base_url="${1:?用法: isrvd_login <api_root> <username> <password> [totpCode]}"
   local username="${2:?缺少 username}"
   local password="${3:?缺少 password}"
   local totp_code="${4:-}"
 
-  ISRVD_BASE_URL="${base_url%/}"
+  ISRVD_BASE_URL=$(_isrvd_api_root "$base_url")
   ISRVD_USERNAME="$username"
 
   _blue "→ 登录 $ISRVD_BASE_URL ..."
@@ -71,7 +87,7 @@ isrvd_login() {
     '{username:$username,password:$password} + (if $totpCode == "" then {} else {totpCode:$totpCode} end)')
 
   local resp
-  resp=$(curl -sf -X POST "$ISRVD_BASE_URL/api/account/login" \
+  resp=$(curl -sf -X POST "$(_isrvd_api_url '/account/login')" \
     -H "Content-Type: application/json" \
     -d "$body" 2>&1) || {
     _red "✗ 登录失败: $resp"
@@ -88,7 +104,7 @@ isrvd_login() {
   local two_factor_required
   two_factor_required=$(echo "$resp" | jq -r '.payload.twoFactorRequired // false')
   if [ "$two_factor_required" = "true" ]; then
-    _red "✗ 该账号已启用 TOTP 二次验证。请使用: isrvd_login <base_url> <username> <password> <totpCode>"
+    _red "✗ 该账号已启用 TOTP 二次验证。请使用: isrvd_login <api_root> <username> <password> <totpCode>"
     return 1
   fi
 
@@ -105,17 +121,17 @@ isrvd_login() {
 # isrvd_token — 直接用 token 认证，保存到配置文件
 # ---------------------------------------------------------------------------
 isrvd_token() {
-  local base_url="${1:?用法: isrvd_token <base_url> <token>}"
+  local base_url="${1:?用法: isrvd_token <api_root> <token>}"
   local token="${2:?缺少 token}"
 
-  ISRVD_BASE_URL="${base_url%/}"
+  ISRVD_BASE_URL=$(_isrvd_api_root "$base_url")
   ISRVD_TOKEN="$token"
   ISRVD_USERNAME=""
 
   # 验证 token 有效性
   _blue "→ 验证 token ..."
   local resp
-  resp=$(curl -sf "$ISRVD_BASE_URL/api/overview/bootstrap" \
+  resp=$(curl -sf "$(_isrvd_api_url '/overview/bootstrap')" \
     -H "$(_isrvd_auth_header)" 2>&1) || {
     _red "✗ token 无效或服务不可达"
     return 1
@@ -141,8 +157,8 @@ _isrvd_check() {
 
   if [ -z "$ISRVD_BASE_URL" ] || [ -z "$ISRVD_TOKEN" ]; then
     _red "✗ 未认证。请先执行:" >&2
-    _red "  isrvd_login <base_url> <username> <password>" >&2
-    _red "  isrvd_token <base_url> <token>" >&2
+    _red "  isrvd_login <api_root> <username> <password>" >&2
+    _red "  isrvd_token <api_root> <token>" >&2
     return 1
   fi
 }
@@ -235,7 +251,7 @@ _isrvd_curl() {
 
   _isrvd_check || return 1
 
-  local url="$ISRVD_BASE_URL/api${path}"
+  local url="$(_isrvd_api_url "$path")"
   local args=(
     -s -w "\n%{http_code}"
     -X "$method"
@@ -297,7 +313,7 @@ isrvd_upload() {
 
   _isrvd_check || return 1
 
-  local url="$ISRVD_BASE_URL/api${path}"
+  local url="$(_isrvd_api_url "$path")"
   local args=(
     -s
     -X POST
@@ -356,8 +372,8 @@ isrvd_help() {
 isrvd API Harness
 
   认证（持久化到 ~/.config/isrvd/profile.json）:
-    isrvd_login  <url> <user> <pass> [totp]  账号密码登录；启用 TOTP 时传入验证码
-    isrvd_token  <url> <token>           直接用 token
+    isrvd_login  <api_root> <user> <pass> [totp]  账号密码登录；启用 TOTP 时传入验证码
+    isrvd_token  <api_root> <token>                 直接用 token
     isrvd_logout                         清除认证
     isrvd_status                         查看当前配置
     isrvd_whoami                         当前用户信息
@@ -370,10 +386,10 @@ isrvd API Harness
     isrvd_delete <path>                          DELETE
     isrvd_upload <path> <field> <file> [k=v...]  文件上传
 
-  认证优先级: 环境变量 > 配置文件
+  认证优先级: 环境变量 > 配置文件；ISRVD_AUTH_HEADER 可指定自定义认证头（默认 Authorization）
 
   示例:
-    isrvd_token "$ISRVD_APIURL" "$ISRVD_APITOKEN"
+    isrvd_token "$API_ROOT" "$TOKEN"
     isrvd_get "/docker/containers"
     isrvd_post "/docker/container" '{"image":"...","name":"..."}'
     isrvd_get "/swarm/services"


### PR DESCRIPTION
脚本支持传入包含完整路径的 API Root，以适配非 /api 结尾的部署地址
为 Python、Node.js 和 Bash 脚本增加可配置认证请求头，对齐 isrvd 的自定义鉴权 Header 能力
修复 Bash 脚本与 Python、Node.js 脚本行为不一致的问题