### PR TITLE
feat(compose): 支持 .env 编辑、变量插值合并与回滚

### DIFF
--- a/docs/references/compose.md
+++ b/docs/references/compose.md
@@ -9,20 +9,28 @@ Compose 接口用于单机 Docker Compose 与 Swarm Stack 的部署、读取配�
 | 字段 | 类型 | 必填 | 说明 |
 |---|---|---|---|
 | `content` | string | 是 | 完整 compose yaml 文本 |
+| `envContent` | string | 否 | `.env` 内容（`KEY=VALUE`），部署时合并进变量插值环境并写盘 |
 | `initURL` | string | 否 | 附加运行文件 zip 下载地址 |
 | `initFile` | file | 否 | 附加运行文件 zip；与 `initURL` 互斥且文件优先 |
 | `forcePull` | boolean | 否 | `true` 时强制拉取最新镜像（即使本地已存在），默认 `false` |
 
 > Docker 与 Swarm Compose 部署都支持 `initURL` / `initFile`；解压目标为 `docker.containerRoot/<NAME>/`。Swarm 场景下建议 `containerRoot` 指向各节点共享的存储（如 NFS），以便所有节点都能访问解压出的文件。
 
+部署时先浅解析顶层 `name`：支持使用进程环境和请求中 `envContent` 做项目名插值，并按 compose-go 规则转为小写规范名；未声明 `name` 时使用 compose 内容短哈希。随后在任何落盘前做不读取 `env_file` 的结构预检，只在 `.env` 和附加运行文件就位后执行完整 compose 加载。
+
 ### ComposeRedeploy
 
 | 字段 | 类型 | 必填 | 说明 |
 |---|---|---|---|
-| `content` | string | 二选一 | 完整 compose yaml 文本（全量重建） |
-| `serviceName` | string | 二选一 | 要更新镜像的 compose 服务名（按服务更新） |
+| `content` | string | 按需 | 完整 compose yaml 文本（全量重建） |
+| `envContent` | string | 按需 | `.env` 内容（`KEY=VALUE`）；可与 `content` 一起提交，也可单独提交仅更新 `.env` 后重建 |
+| `serviceName` | string | 按需 | 要更新镜像的 compose 服务名（按服务更新） |
 | `image` | string | 按需 | 新镜像名，`serviceName` 非空时必填 |
 | `forcePull` | boolean | 否 | `true` 时强制拉取最新镜像，默认 `false` |
+
+> `content`、`envContent`、`serviceName` 三者至少提交一项；`serviceName` 与 `content` 互斥，`serviceName` 非空时 `image` 必填。
+
+重部署会在正式加载和创建容器/服务前写入新 `.env`，确保 `env_file` 和变量插值使用新值；后续失败时会精确恢复原 `.env` 内容，包括空文件或原本不存在的状态，再回滚旧实例。
 
 ### ComposeDeployResult
 
@@ -37,6 +45,7 @@ Compose 接口用于单机 Docker Compose 与 Swarm Stack 的部署、读取配�
 | 字段 | 类型 | 说明 |
 |---|---|---|
 | `content` | string | compose.yml 文本 |
+| `envContent` | string | `.env` 文本（`KEY=VALUE`）；无落盘文件时不返回 |
 | `projectName` | string | 实际解析到的项目名 |
 | `fileModTime` | number | `docker.containerRoot/<PROJECT>/compose.yml` 修改时间（Unix 秒）；无落盘文件时不返回 |
 | `source` | string | 内容来源：`file` 表示落盘文件，`runtime` 表示从运行态反推 |
@@ -127,6 +136,18 @@ isrvd_put "/compose/docker/<NAME>" "$(jq -n --arg content "$(cat docker-compose.
 
 `<NAME>` 可以是项目名，也可以是该项目下任意一个容器名；后端会通过 `com.docker.compose.project` 解析到项目名后整体重建关联容器。
 
+重部署时同时更新 `.env`：
+
+```bash
+isrvd_put "/compose/docker/<NAME>" "$(jq -n --arg content "$(cat docker-compose.yml)" --arg envContent "$(cat .env)" '{content:$content,envContent:$envContent}')"
+```
+
+仅更新 `.env` 后重建（`content` 省略，沿用现有 compose.yml）：
+
+```bash
+isrvd_put "/compose/docker/<NAME>" "$(jq -n --arg envContent "$(cat .env)" '{envContent:$envContent}')"
+```
+
 ### 按服务更新镜像并重建
 
 ```bash
@@ -167,6 +188,18 @@ Swarm Compose 与 Docker Compose 共用容器目录 `docker.containerRoot/<NAME>
 
 ```bash
 isrvd_put "/compose/swarm/<NAME>" "$(jq -n --arg content "$(cat stack.yml)" '{content:$content}')"
+```
+
+重部署时同时更新 `.env`：
+
+```bash
+isrvd_put "/compose/swarm/<NAME>" "$(jq -n --arg content "$(cat stack.yml)" --arg envContent "$(cat .env)" '{content:$content,envContent:$envContent}')"
+```
+
+仅更新 `.env` 后重建（`content` 省略，沿用现有 compose.yml）：
+
+```bash
+isrvd_put "/compose/swarm/<NAME>" "$(jq -n --arg envContent "$(cat .env)" '{envContent:$envContent}')"
 ```
 
 ### 按服务更新镜像并重建

--- a/docs/references/compose.md
+++ b/docs/references/compose.md
@@ -30,11 +30,13 @@ Compose 接口用于单机 Docker Compose 与 Swarm Stack 的部署、读取配�
 
 > 该接口为部分更新，提交哪个字段就改哪个字段，未提交的字段保持不变；`content`、`envContent`、`serviceName` 三者至少提交一项；`serviceName` 与 `content`、`envContent` 均互斥，`serviceName` 非空时 `image` 必填。
 
-重部署会在正式加载和创建容器/服务前写入新 `.env`，确保 `env_file` 和变量插值使用新值；后续失败时会精确恢复原 `.env` 内容，包括空文件或原本不存在的状态，再回滚旧实例。
+重部署会在正式加载和创建容器/服务前写入新 `.env`，确保 `env_file` 和变量插值使用新值。旧实例删除后若后续步骤失败，会尝试恢复原 `.env`（含空文件或原本不存在的状态）并重建旧容器/服务；`.env` 恢复失败只记日志，不阻断实例回滚。错误响应的 `message` 会附带回滚摘要，例如：`原错误；回滚：.env 回滚失败（…），容器回滚成功`（Swarm 为「服务回滚」）。
+
+读取 Compose 配置时若落盘 `.env` 存在但读取失败（权限/IO），接口直接报错，不会把空串当作「无文件」。
 
 ### 变量插值优先级
 
-插值环境优先级从低到高为：进程环境 < `.env`。提交 `envContent` 时该内容即为 `.env`，不会与磁盘上原有 `.env` 叠加。这与 docker compose（shell 环境覆盖 `.env`）相反，目的是让界面上编辑的 `.env` 成为权威来源。
+插值环境优先级从低到高为：磁盘 `.env` < 请求中显式提交的 `envContent` < 进程环境（与 docker compose 一致，shell 已存在的变量覆盖 `.env`）。显式 `envContent` 在磁盘 `.env` 之上叠加，同键时显式内容优先。
 
 ### ComposeDeployResult
 

--- a/docs/references/compose.md
+++ b/docs/references/compose.md
@@ -9,28 +9,32 @@ Compose 接口用于单机 Docker Compose 与 Swarm Stack 的部署、读取配�
 | 字段 | 类型 | 必填 | 说明 |
 |---|---|---|---|
 | `content` | string | 是 | 完整 compose yaml 文本 |
-| `envContent` | string | 否 | `.env` 内容（`KEY=VALUE`），部署时合并进变量插值环境并写盘 |
+| `envContent` | string | 否 | `.env` 内容（`KEY=VALUE`）；省略则保留附加文件解压出的 `.env`，提交则以其为准写盘并合并进变量插值环境 |
 | `initURL` | string | 否 | 附加运行文件 zip 下载地址 |
 | `initFile` | file | 否 | 附加运行文件 zip；与 `initURL` 互斥且文件优先 |
 | `forcePull` | boolean | 否 | `true` 时强制拉取最新镜像（即使本地已存在），默认 `false` |
 
 > Docker 与 Swarm Compose 部署都支持 `initURL` / `initFile`；解压目标为 `docker.containerRoot/<NAME>/`。Swarm 场景下建议 `containerRoot` 指向各节点共享的存储（如 NFS），以便所有节点都能访问解压出的文件。
 
-部署时先浅解析顶层 `name`：支持使用进程环境和请求中 `envContent` 做项目名插值，并按 compose-go 规则转为小写规范名；未声明 `name` 时使用 compose 内容短哈希。随后在任何落盘前做不读取 `env_file` 的结构预检，只在 `.env` 和附加运行文件就位后执行完整 compose 加载。
+部署前先做不读取 `env_file` 的结构预检并从中取得项目名（已插值并按 compose-go 规则规范化为小写）；完全未声明 `name` 时用 compose 内容短哈希兜底；若声明了 `name` 但其插值变量未提供，部署直接报错而不会退回哈希。
 
 ### ComposeRedeploy
 
 | 字段 | 类型 | 必填 | 说明 |
 |---|---|---|---|
-| `content` | string | 按需 | 完整 compose yaml 文本（全量重建） |
-| `envContent` | string | 按需 | `.env` 内容（`KEY=VALUE`）；可与 `content` 一起提交，也可单独提交仅更新 `.env` 后重建 |
+| `content` | string | 按需 | 完整 compose yaml 文本；省略表示沿用现有 compose.yml，提交空字符串会被拒绝 |
+| `envContent` | string | 按需 | `.env` 内容（`KEY=VALUE`）；省略表示保留现有 `.env`，提交空字符串表示清空，提交内容表示覆盖 |
 | `serviceName` | string | 按需 | 要更新镜像的 compose 服务名（按服务更新） |
 | `image` | string | 按需 | 新镜像名，`serviceName` 非空时必填 |
 | `forcePull` | boolean | 否 | `true` 时强制拉取最新镜像，默认 `false` |
 
-> `content`、`envContent`、`serviceName` 三者至少提交一项；`serviceName` 与 `content` 互斥，`serviceName` 非空时 `image` 必填。
+> 该接口为部分更新，提交哪个字段就改哪个字段，未提交的字段保持不变；`content`、`envContent`、`serviceName` 三者至少提交一项；`serviceName` 与 `content`、`envContent` 均互斥，`serviceName` 非空时 `image` 必填。
 
 重部署会在正式加载和创建容器/服务前写入新 `.env`，确保 `env_file` 和变量插值使用新值；后续失败时会精确恢复原 `.env` 内容，包括空文件或原本不存在的状态，再回滚旧实例。
+
+### 变量插值优先级
+
+插值环境优先级从低到高为：进程环境 < `.env`。提交 `envContent` 时该内容即为 `.env`，不会与磁盘上原有 `.env` 叠加。这与 docker compose（shell 环境覆盖 `.env`）相反，目的是让界面上编辑的 `.env` 成为权威来源。
 
 ### ComposeDeployResult
 
@@ -148,6 +152,12 @@ isrvd_put "/compose/docker/<NAME>" "$(jq -n --arg content "$(cat docker-compose.
 isrvd_put "/compose/docker/<NAME>" "$(jq -n --arg envContent "$(cat .env)" '{envContent:$envContent}')"
 ```
 
+清空 `.env`（提交空字符串）：
+
+```bash
+isrvd_put "/compose/docker/<NAME>" "$(jq -n --arg content "$(cat docker-compose.yml)" '{content:$content,envContent:""}')"
+```
+
 ### 按服务更新镜像并重建
 
 ```bash
@@ -200,6 +210,12 @@ isrvd_put "/compose/swarm/<NAME>" "$(jq -n --arg content "$(cat stack.yml)" --ar
 
 ```bash
 isrvd_put "/compose/swarm/<NAME>" "$(jq -n --arg envContent "$(cat .env)" '{envContent:$envContent}')"
+```
+
+清空 `.env`（提交空字符串）：
+
+```bash
+isrvd_put "/compose/swarm/<NAME>" "$(jq -n --arg content "$(cat stack.yml)" '{content:$content,envContent:""}')"
 ```
 
 ### 按服务更新镜像并重建

--- a/internal/server/ctrl_compose.go
+++ b/internal/server/ctrl_compose.go
@@ -143,7 +143,9 @@ func bindComposeDeployRequest(c *gin.Context) (svcCompose.DeployRequest, bool) {
 		}
 	} else {
 		req.Content = c.PostForm("content")
-		req.EnvContent = c.PostForm("envContent")
+		if v, ok := c.GetPostForm("envContent"); ok {
+			req.EnvContent = &v
+		}
 		req.InitURL = c.PostForm("initURL")
 		if fh, err := c.FormFile("initFile"); err == nil {
 			if fh.Size > config.Server.MaxUploadSize {

--- a/internal/server/ctrl_compose.go
+++ b/internal/server/ctrl_compose.go
@@ -143,6 +143,7 @@ func bindComposeDeployRequest(c *gin.Context) (svcCompose.DeployRequest, bool) {
 		}
 	} else {
 		req.Content = c.PostForm("content")
+		req.EnvContent = c.PostForm("envContent")
 		req.InitURL = c.PostForm("initURL")
 		if fh, err := c.FormFile("initFile"); err == nil {
 			if fh.Size > config.Server.MaxUploadSize {

--- a/internal/service/compose/docker.go
+++ b/internal/service/compose/docker.go
@@ -53,6 +53,9 @@ func (s *Service) DockerDeploy(ctx context.Context, req DeployRequest) (*DeployR
 		return nil, err
 	}
 
+	// 写 .env（显式内容优先；附加文件解压的 .env 已存在则保留，否则兜底空文件）
+	compose.EnvSave(installDir, req.EnvContent, "")
+
 	project, err = compose.ProjectLoad(ctx, projectName, req.Content, installDir)
 	if err != nil {
 		return nil, err
@@ -105,7 +108,13 @@ func (s *Service) DockerContentResult(ctx context.Context, name string, forceRun
 	fileModTime := composeFileModTime(path)
 	if !forceRuntime {
 		if data, err := os.ReadFile(path); err == nil {
-			return &ContentResult{Content: string(data), ProjectName: projectName, FileModTime: fileModTime, Source: "file"}, nil
+			return &ContentResult{
+				Content:     string(data),
+				EnvContent:  compose.EnvContentRead(filepath.Join(root, projectName)),
+				ProjectName: projectName,
+				FileModTime: fileModTime,
+				Source:      "file",
+			}, nil
 		}
 	}
 
@@ -113,7 +122,13 @@ func (s *Service) DockerContentResult(ctx context.Context, name string, forceRun
 		if err != nil {
 			return nil, err
 		}
-		return &ContentResult{Content: content, ProjectName: projectName, FileModTime: fileModTime, Source: "runtime"}, nil
+		return &ContentResult{
+			Content:     content,
+			EnvContent:  compose.EnvContentRead(filepath.Join(root, projectName)),
+			ProjectName: projectName,
+			FileModTime: fileModTime,
+			Source:      "runtime",
+		}, nil
 	}
 
 	info, err := s.docker.ContainerInspectRaw(ctx, name)
@@ -128,7 +143,9 @@ func (s *Service) DockerContentResult(ctx context.Context, name string, forceRun
 }
 
 // DockerRedeploy 重建 Docker Compose 项目。
-// ServiceName+Image 非空时仅更新指定服务镜像，否则用 Content 全量重建。
+// - ServiceName+Image 非空：仅更新指定服务镜像后重建
+// - EnvContent 单独非空（Content 为空）：仅更新 .env 后重建
+// - Content 非空：全量重建（compose 与 .env 均可替换）
 func (s *Service) DockerRedeploy(ctx context.Context, name string, req RedeployRequest) (*DeployResult, error) {
 	if err := compose.ValidateProjectName(name); err != nil {
 		return nil, err
@@ -146,6 +163,8 @@ func (s *Service) DockerRedeploy(ctx context.Context, name string, req RedeployR
 		installDir = filepath.Join(root, name)
 	}
 
+	oldEnv := compose.EnvContentRead(installDir)
+
 	content := req.Content
 	if req.ServiceName != "" {
 		oldContent, _, err := s.DockerContent(ctx, name)
@@ -160,8 +179,13 @@ func (s *Service) DockerRedeploy(ctx context.Context, name string, req RedeployR
 
 	oldContent, _, _ := s.DockerContent(ctx, name)
 
+	// 仅更新 .env（content 为空）时，沿用现有 compose 内容
+	if content == "" {
+		content = oldContent
+	}
+
 	// 先校验新 content，失败时旧服务保持运行
-	newProject, err := compose.ProjectParse(ctx, name, content, installDir)
+	newProject, err := compose.LoadProjectFromContentWithEnv(ctx, content, installDir, name, req.EnvContent)
 	if err != nil {
 		return nil, err
 	}
@@ -177,6 +201,7 @@ func (s *Service) DockerRedeploy(ctx context.Context, name string, req RedeployR
 	rollback := func() {
 		s.dockerRollback(ctx, name, oldContent, installDir)
 		compose.ContentSave(installDir, oldContent, "")
+		compose.EnvSave(installDir, oldEnv, "")
 	}
 
 	project, err := compose.ProjectLoad(ctx, name, content, installDir)
@@ -192,6 +217,7 @@ func (s *Service) DockerRedeploy(ctx context.Context, name string, req RedeployR
 	}
 
 	compose.ContentSave(installDir, content, oldContent)
+	compose.EnvSave(installDir, req.EnvContent, oldEnv)
 
 	logman.Info("Compose redeployed", "name", name)
 	return &DeployResult{ProjectName: name, Items: items, InstallDir: installDir}, nil

--- a/internal/service/compose/docker.go
+++ b/internal/service/compose/docker.go
@@ -67,8 +67,12 @@ func (s *Service) DockerDeploy(ctx context.Context, req DeployRequest) (*DeployR
 		return nil, err
 	}
 
-	// 写 .env（显式内容优先；附加文件解压的 .env 已存在则保留，否则兜底空文件）
-	if err := compose.EnvSave(installDir, req.EnvContent, ""); err != nil {
+	// 写 .env：显式提交则以其为准（空串即清空），未提交则保留附加文件解压出的 .env 并兜底空文件
+	if req.EnvContent != nil {
+		if err := compose.EnvSave(installDir, *req.EnvContent, ""); err != nil {
+			return nil, err
+		}
+	} else if err := compose.EnvEnsure(installDir); err != nil {
 		return nil, err
 	}
 
@@ -155,13 +159,20 @@ func (s *Service) DockerContentResult(ctx context.Context, name string, forceRun
 	if err != nil {
 		return nil, err
 	}
-	return &ContentResult{Content: content, ProjectName: projectName, FileModTime: fileModTime, Source: "runtime"}, nil
+	return &ContentResult{
+		Content:     content,
+		EnvContent:  compose.EnvContentRead(filepath.Join(root, projectName)),
+		ProjectName: projectName,
+		FileModTime: fileModTime,
+		Source:      "runtime",
+	}, nil
 }
 
 // DockerRedeploy 重建 Docker Compose 项目。
-// - ServiceName+Image 非空：仅更新指定服务镜像后重建
-// - EnvContent 单独非空（Content 为空）：仅更新 .env 后重建
-// - Content 非空：全量重建（compose 与 .env 均可替换）
+// 部分更新：提交哪个字段就改哪个字段，未提交的字段保持不变。
+// - ServiceName+Image：仅更新指定服务镜像后重建
+// - Content：替换 compose.yml 后重建
+// - EnvContent：替换 .env（空串即清空）后重建
 func (s *Service) DockerRedeploy(ctx context.Context, name string, req RedeployRequest) (*DeployResult, error) {
 	if err := compose.ValidateProjectName(name); err != nil {
 		return nil, err
@@ -185,23 +196,26 @@ func (s *Service) DockerRedeploy(ctx context.Context, name string, req RedeployR
 	}
 	oldEnv := oldEnvState.Content
 
-	content := req.Content
-	if req.ServiceName != "" {
-		oldContent, _, err := s.DockerContent(ctx, name)
-		if err != nil {
-			return nil, err
+	oldContent, _, contentErr := s.DockerContent(ctx, name)
+
+	// 准备新 content：未提交则沿用现有 compose 内容
+	content := oldContent
+	switch {
+	case req.ServiceName != "":
+		if contentErr != nil {
+			return nil, contentErr
 		}
 		content, err = compose.UpdateServiceImage(ctx, name, oldContent, req.ServiceName, req.Image)
 		if err != nil {
 			return nil, err
 		}
-	}
-
-	oldContent, _, _ := s.DockerContent(ctx, name)
-
-	// 仅更新 .env（content 为空）时，沿用现有 compose 内容
-	if content == "" {
-		content = oldContent
+	case req.Content != nil:
+		content = *req.Content
+	default:
+		// 仅更新 .env：必须能读到现有 compose 内容
+		if contentErr != nil {
+			return nil, contentErr
+		}
 	}
 
 	// 先校验新 content，失败时旧服务保持运行
@@ -229,7 +243,12 @@ func (s *Service) DockerRedeploy(ctx context.Context, name string, req RedeployR
 	}
 
 	// 先落盘新 .env，确保 ProjectLoad 插值读取到新值（与 Deploy 流程顺序一致）
-	if err := compose.EnvSave(installDir, req.EnvContent, oldEnv); err != nil {
+	if req.EnvContent != nil {
+		if err := compose.EnvSave(installDir, *req.EnvContent, oldEnv); err != nil {
+			rollback()
+			return nil, err
+		}
+	} else if err := compose.EnvEnsure(installDir); err != nil {
 		rollback()
 		return nil, err
 	}

--- a/internal/service/compose/docker.go
+++ b/internal/service/compose/docker.go
@@ -128,9 +128,13 @@ func (s *Service) DockerContentResult(ctx context.Context, name string, forceRun
 	fileModTime := composeFileModTime(path)
 	if !forceRuntime {
 		if data, err := os.ReadFile(path); err == nil {
+			envContent, err := compose.EnvContentRead(filepath.Join(root, projectName))
+			if err != nil {
+				return nil, err
+			}
 			return &ContentResult{
 				Content:     string(data),
-				EnvContent:  compose.EnvContentRead(filepath.Join(root, projectName)),
+				EnvContent:  envContent,
 				ProjectName: projectName,
 				FileModTime: fileModTime,
 				Source:      "file",
@@ -142,9 +146,13 @@ func (s *Service) DockerContentResult(ctx context.Context, name string, forceRun
 		if err != nil {
 			return nil, err
 		}
+		envContent, err := compose.EnvContentRead(filepath.Join(root, projectName))
+		if err != nil {
+			return nil, err
+		}
 		return &ContentResult{
 			Content:     content,
-			EnvContent:  compose.EnvContentRead(filepath.Join(root, projectName)),
+			EnvContent:  envContent,
 			ProjectName: projectName,
 			FileModTime: fileModTime,
 			Source:      "runtime",
@@ -159,9 +167,13 @@ func (s *Service) DockerContentResult(ctx context.Context, name string, forceRun
 	if err != nil {
 		return nil, err
 	}
+	envContent, err := compose.EnvContentRead(filepath.Join(root, projectName))
+	if err != nil {
+		return nil, err
+	}
 	return &ContentResult{
 		Content:     content,
-		EnvContent:  compose.EnvContentRead(filepath.Join(root, projectName)),
+		EnvContent:  envContent,
 		ProjectName: projectName,
 		FileModTime: fileModTime,
 		Source:      "runtime",
@@ -232,37 +244,37 @@ func (s *Service) DockerRedeploy(ctx context.Context, name string, req RedeployR
 
 	s.dockerContainersRemove(ctx, name, oldContent)
 
-	rollback := func() {
-		// 先恢复旧 .env 再回滚容器，确保回滚容器使用旧环境变量
+	rollback := func() string {
+		// 先恢复旧 .env 再回滚容器；.env 失败不阻断容器回滚
 		compose.ContentSave(installDir, oldContent, "")
-		if err := compose.EnvStateRestore(installDir, oldEnvState); err != nil {
-			logman.Warn("Restore compose env before rollback failed", "name", name, "error", err)
-			return
+		envErr := compose.EnvStateRestore(installDir, oldEnvState)
+		if envErr != nil {
+			logman.Warn("Restore compose env before rollback failed", "name", name, "error", envErr)
 		}
-		s.dockerRollback(ctx, name, oldContent, installDir)
+		runtimeErr := s.dockerRollback(ctx, name, oldContent, installDir)
+		if runtimeErr != nil {
+			logman.Warn("Rollback containers failed", "name", name, "error", runtimeErr)
+		}
+		return formatRedeployRollbackSummary(envErr == nil, envErr, runtimeErr == nil, runtimeErr, "容器")
 	}
 
 	// 先落盘新 .env，确保 ProjectLoad 插值读取到新值（与 Deploy 流程顺序一致）
 	if req.EnvContent != nil {
 		if err := compose.EnvSave(installDir, *req.EnvContent, oldEnv); err != nil {
-			rollback()
-			return nil, err
+			return nil, wrapRedeployError(err, rollback())
 		}
 	} else if err := compose.EnvEnsure(installDir); err != nil {
-		rollback()
-		return nil, err
+		return nil, wrapRedeployError(err, rollback())
 	}
 
 	project, err := compose.ProjectLoad(ctx, name, content, installDir)
 	if err != nil {
-		rollback()
-		return nil, err
+		return nil, wrapRedeployError(err, rollback())
 	}
 
 	items, err := s.dockerServicesCreate(ctx, project)
 	if err != nil {
-		rollback()
-		return nil, err
+		return nil, wrapRedeployError(err, rollback())
 	}
 
 	compose.ContentSave(installDir, content, oldContent)
@@ -410,18 +422,18 @@ func (s *Service) dockerProjectContentFromContainers(ctx context.Context, projec
 }
 
 // dockerRollback 用指定配置内容重建容器（回滚用）
-func (s *Service) dockerRollback(ctx context.Context, name, content, installDir string) {
+func (s *Service) dockerRollback(ctx context.Context, name, content, installDir string) error {
 	if content == "" {
-		return
+		return fmt.Errorf("无可回滚的 compose 内容")
 	}
 	project, err := compose.ProjectParse(ctx, name, content, installDir)
 	if err != nil {
-		logman.Warn("Rollback load project failed", "name", name, "error", err)
-		return
+		return fmt.Errorf("加载回滚配置失败: %w", err)
 	}
 	if _, err := s.dockerServicesCreate(ctx, project); err != nil {
-		logman.Warn("Rollback deploy failed", "name", name, "error", err)
+		return fmt.Errorf("重建容器失败: %w", err)
 	}
+	return nil
 }
 
 // dockerEnsureNetworks 确保 project 所需网络存在，不存在则创建 bridge 网络

--- a/internal/service/compose/docker.go
+++ b/internal/service/compose/docker.go
@@ -21,13 +21,14 @@ func (s *Service) DockerDeploy(ctx context.Context, req DeployRequest) (*DeployR
 		return nil, fmt.Errorf("未配置容器数据根目录")
 	}
 
-	// 项目名探测：浅解析提取顶层 name，不做完整 compose 解析（不解析 env_file），
-	// 避免在 .env 尚未写盘时报 env file not found
-	projectName, err := compose.ProjectNameFromContentShallow(ctx, req.Content, req.EnvContent)
+	// 部署前预检：不解析 env_file（避免 .env 尚未写盘时报错），
+	// 返回的 project.Name 已插值+规范化；无 name 时已用内容短哈希兜底
+	pre, err := compose.ProjectValidateWithoutEnvFiles(ctx, req.Content, req.EnvContent)
 	if err != nil {
 		return nil, err
 	}
-	if err := compose.ProjectValidateWithoutEnvFiles(ctx, projectName, req.Content, req.EnvContent); err != nil {
+	projectName, err := compose.ProjectNameFromProject(pre, req.Content)
+	if err != nil {
 		return nil, err
 	}
 

--- a/internal/service/compose/docker.go
+++ b/internal/service/compose/docker.go
@@ -21,11 +21,9 @@ func (s *Service) DockerDeploy(ctx context.Context, req DeployRequest) (*DeployR
 		return nil, fmt.Errorf("未配置容器数据根目录")
 	}
 
-	project, err := compose.LoadProjectFromContent(ctx, req.Content, "")
-	if err != nil {
-		return nil, err
-	}
-	projectName, err := compose.ProjectNameFromProject(project, req.Content)
+	// 项目名探测：浅解析提取顶层 name，不做完整 compose 解析（不解析 env_file），
+	// 避免在 .env 尚未写盘时报 env file not found
+	projectName, err := compose.ProjectNameFromContentShallow(req.Content)
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +54,7 @@ func (s *Service) DockerDeploy(ctx context.Context, req DeployRequest) (*DeployR
 	// 写 .env（显式内容优先；附加文件解压的 .env 已存在则保留，否则兜底空文件）
 	compose.EnvSave(installDir, req.EnvContent, "")
 
-	project, err = compose.ProjectLoad(ctx, projectName, req.Content, installDir)
+	project, err := compose.ProjectLoad(ctx, projectName, req.Content, installDir)
 	if err != nil {
 		return nil, err
 	}
@@ -199,10 +197,14 @@ func (s *Service) DockerRedeploy(ctx context.Context, name string, req RedeployR
 	s.dockerContainersRemove(ctx, name, oldContent)
 
 	rollback := func() {
-		s.dockerRollback(ctx, name, oldContent, installDir)
+		// 先恢复旧 .env 再回滚容器，确保回滚容器使用旧环境变量
 		compose.ContentSave(installDir, oldContent, "")
 		compose.EnvSave(installDir, oldEnv, "")
+		s.dockerRollback(ctx, name, oldContent, installDir)
 	}
+
+	// 先落盘新 .env，确保 ProjectLoad 插值读取到新值（与 Deploy 流程顺序一致）
+	compose.EnvSave(installDir, req.EnvContent, oldEnv)
 
 	project, err := compose.ProjectLoad(ctx, name, content, installDir)
 	if err != nil {
@@ -217,7 +219,6 @@ func (s *Service) DockerRedeploy(ctx context.Context, name string, req RedeployR
 	}
 
 	compose.ContentSave(installDir, content, oldContent)
-	compose.EnvSave(installDir, req.EnvContent, oldEnv)
 
 	logman.Info("Compose redeployed", "name", name)
 	return &DeployResult{ProjectName: name, Items: items, InstallDir: installDir}, nil

--- a/internal/service/compose/docker.go
+++ b/internal/service/compose/docker.go
@@ -23,8 +23,11 @@ func (s *Service) DockerDeploy(ctx context.Context, req DeployRequest) (*DeployR
 
 	// 项目名探测：浅解析提取顶层 name，不做完整 compose 解析（不解析 env_file），
 	// 避免在 .env 尚未写盘时报 env file not found
-	projectName, err := compose.ProjectNameFromContentShallow(req.Content)
+	projectName, err := compose.ProjectNameFromContentShallow(ctx, req.Content, req.EnvContent)
 	if err != nil {
+		return nil, err
+	}
+	if err := compose.ProjectValidateWithoutEnvFiles(ctx, projectName, req.Content, req.EnvContent); err != nil {
 		return nil, err
 	}
 
@@ -36,11 +39,23 @@ func (s *Service) DockerDeploy(ctx context.Context, req DeployRequest) (*DeployR
 
 	_, err = os.Stat(installDir)
 	installDirExists := err == nil
+	initialEnvState, err := compose.EnvStateRead(installDir)
+	if err != nil {
+		return nil, err
+	}
 
 	deployed := false
 	defer func() {
-		if !deployed && !installDirExists {
+		if deployed {
+			return
+		}
+		if !installDirExists {
 			_ = os.RemoveAll(installDir)
+			return
+		}
+		_ = os.Remove(composeFile)
+		if err := compose.EnvStateRestore(installDir, initialEnvState); err != nil {
+			logman.Warn("Restore compose env after failed deploy", "name", projectName, "error", err)
 		}
 	}()
 
@@ -52,7 +67,9 @@ func (s *Service) DockerDeploy(ctx context.Context, req DeployRequest) (*DeployR
 	}
 
 	// 写 .env（显式内容优先；附加文件解压的 .env 已存在则保留，否则兜底空文件）
-	compose.EnvSave(installDir, req.EnvContent, "")
+	if err := compose.EnvSave(installDir, req.EnvContent, ""); err != nil {
+		return nil, err
+	}
 
 	project, err := compose.ProjectLoad(ctx, projectName, req.Content, installDir)
 	if err != nil {
@@ -161,7 +178,11 @@ func (s *Service) DockerRedeploy(ctx context.Context, name string, req RedeployR
 		installDir = filepath.Join(root, name)
 	}
 
-	oldEnv := compose.EnvContentRead(installDir)
+	oldEnvState, err := compose.EnvStateRead(installDir)
+	if err != nil {
+		return nil, err
+	}
+	oldEnv := oldEnvState.Content
 
 	content := req.Content
 	if req.ServiceName != "" {
@@ -199,12 +220,18 @@ func (s *Service) DockerRedeploy(ctx context.Context, name string, req RedeployR
 	rollback := func() {
 		// 先恢复旧 .env 再回滚容器，确保回滚容器使用旧环境变量
 		compose.ContentSave(installDir, oldContent, "")
-		compose.EnvSave(installDir, oldEnv, "")
+		if err := compose.EnvStateRestore(installDir, oldEnvState); err != nil {
+			logman.Warn("Restore compose env before rollback failed", "name", name, "error", err)
+			return
+		}
 		s.dockerRollback(ctx, name, oldContent, installDir)
 	}
 
 	// 先落盘新 .env，确保 ProjectLoad 插值读取到新值（与 Deploy 流程顺序一致）
-	compose.EnvSave(installDir, req.EnvContent, oldEnv)
+	if err := compose.EnvSave(installDir, req.EnvContent, oldEnv); err != nil {
+		rollback()
+		return nil, err
+	}
 
 	project, err := compose.ProjectLoad(ctx, name, content, installDir)
 	if err != nil {

--- a/internal/service/compose/service.go
+++ b/internal/service/compose/service.go
@@ -20,9 +20,10 @@ type Service struct {
 }
 
 // DeployRequest 部署请求
+// EnvContent 三态：nil 保留附加文件解压出的 .env；非 nil 时以其为准写盘（空串即清空）
 type DeployRequest struct {
 	Content    string    `json:"content" binding:"required"` // compose.yml 文件内容（必填）
-	EnvContent string    `json:"envContent,omitempty"`       // 附加 .env 内容（KEY=VALUE），合并进插值环境并写盘
+	EnvContent *string   `json:"envContent,omitempty"`       // .env 内容（KEY=VALUE）；nil 表示保留附加文件解压出的 .env，非 nil 时以其为准写盘（空串即清空）
 	InitURL    string    `json:"initURL,omitempty"`          // 附加运行文件 zip 的下载地址（可选）
 	InitFile   io.Reader `json:"-"`                          // 附加运行文件（multipart 上传，不在 JSON 中）
 	ForcePull  bool      `json:"forcePull,omitempty"`        // 是否强制拉取最新镜像
@@ -45,15 +46,14 @@ type ContentResult struct {
 }
 
 // RedeployRequest 重建请求
-// - ServiceName + Image 非空：从现有内容读取后更新指定服务镜像重建
-// - 否则：Content 非空时全量重建（compose 与 .env 均可用新内容替换）
-// - EnvContent 单独变更：Content 可省略，仅更新 .env 后重建
+// 部分更新语义——提交哪个字段就改哪个字段，未提交的字段保持不变；ServiceName + Image 用于仅更新指定服务镜像，与 Content / EnvContent 互斥。
+// EnvContent 三态：nil 保留现有 .env，空串清空，非空覆盖
 type RedeployRequest struct {
-	Content     string `json:"content,omitempty"`     // compose.yml 内容（未指定 serviceName 时与 envContent 至少其一必填，用于全量重建）
-	EnvContent  string `json:"envContent,omitempty"`  // .env 内容（可单独变更，与 content 一起更新时生效）
-	ServiceName string `json:"serviceName,omitempty"` // 目标服务名（与 image 配合，仅更新该服务镜像后重建）
-	Image       string `json:"image,omitempty"`       // 新镜像（指定 serviceName 时必填）
-	ForcePull   bool   `json:"forcePull,omitempty"`   // 是否强制拉取最新镜像
+	Content     *string `json:"content,omitempty"`     // compose.yml 内容；nil 表示沿用现有 compose.yml，提交空串报错
+	EnvContent  *string `json:"envContent,omitempty"`  // .env 内容（KEY=VALUE）；nil 表示保留现有 .env，空串表示清空，非空表示覆盖
+	ServiceName string  `json:"serviceName,omitempty"` // 目标服务名（与 image 配合，仅更新该服务镜像后重建）
+	Image       string  `json:"image,omitempty"`       // 新镜像（指定 serviceName 时必填）
+	ForcePull   bool    `json:"forcePull,omitempty"`   // 是否强制拉取最新镜像
 }
 
 // Validate 校验重建请求的互斥参数
@@ -61,11 +61,17 @@ func (r RedeployRequest) Validate() error {
 	if r.ServiceName != "" && r.Image == "" {
 		return fmt.Errorf("指定服务名时 image 不能为空")
 	}
-	if r.ServiceName != "" && r.Content != "" {
+	if r.ServiceName != "" && r.Content != nil {
 		return fmt.Errorf("指定服务名时不能同时提交 content")
 	}
-	if r.ServiceName == "" && r.Content == "" && r.EnvContent == "" {
-		return fmt.Errorf("未指定服务名时 content 或 envContent 至少一项不能为空")
+	if r.ServiceName != "" && r.EnvContent != nil {
+		return fmt.Errorf("指定服务名时不能同时提交 envContent")
+	}
+	if r.Content != nil && *r.Content == "" {
+		return fmt.Errorf("content 不能为空字符串")
+	}
+	if r.ServiceName == "" && r.Content == nil && r.EnvContent == nil {
+		return fmt.Errorf("未指定服务名时 content 与 envContent 至少需提交一项")
 	}
 	return nil
 }

--- a/internal/service/compose/service.go
+++ b/internal/service/compose/service.go
@@ -106,3 +106,25 @@ func (s *Service) imagesEnsure(ctx context.Context, project *types.Project, forc
 	}
 	return nil
 }
+
+// formatRedeployRollbackSummary 汇总重建失败后的回滚结果，供前端展示。
+// runtimeLabel 为「容器」或「服务」。
+func formatRedeployRollbackSummary(envOK bool, envErr error, runtimeOK bool, runtimeErr error, runtimeLabel string) string {
+	envPart := ".env 回滚成功"
+	if !envOK {
+		envPart = fmt.Sprintf(".env 回滚失败（%v）", envErr)
+	}
+	runtimePart := runtimeLabel + "回滚成功"
+	if !runtimeOK {
+		runtimePart = fmt.Sprintf("%s回滚失败（%v）", runtimeLabel, runtimeErr)
+	}
+	return envPart + "，" + runtimePart
+}
+
+// wrapRedeployError 将原始重建错误与回滚摘要一并返回。
+func wrapRedeployError(err error, rollbackSummary string) error {
+	if err == nil {
+		return fmt.Errorf("重建失败；回滚：%s", rollbackSummary)
+	}
+	return fmt.Errorf("%w；回滚：%s", err, rollbackSummary)
+}

--- a/internal/service/compose/service.go
+++ b/internal/service/compose/service.go
@@ -22,10 +22,10 @@ type Service struct {
 // DeployRequest 部署请求
 type DeployRequest struct {
 	Content    string    `json:"content" binding:"required"` // compose.yml 文件内容（必填）
-	EnvContent string    `json:"envContent,omitempty"`        // 附加 .env 内容（KEY=VALUE），合并进插值环境并写盘
-	InitURL    string    `json:"initURL,omitempty"`           // 附加运行文件 zip 的下载地址（可选）
-	InitFile   io.Reader `json:"-"`                           // 附加运行文件（multipart 上传，不在 JSON 中）
-	ForcePull  bool      `json:"forcePull,omitempty"`         // 是否强制拉取最新镜像
+	EnvContent string    `json:"envContent,omitempty"`       // 附加 .env 内容（KEY=VALUE），合并进插值环境并写盘
+	InitURL    string    `json:"initURL,omitempty"`          // 附加运行文件 zip 的下载地址（可选）
+	InitFile   io.Reader `json:"-"`                          // 附加运行文件（multipart 上传，不在 JSON 中）
+	ForcePull  bool      `json:"forcePull,omitempty"`        // 是否强制拉取最新镜像
 }
 
 // DeployResult 部署结果

--- a/internal/service/compose/service.go
+++ b/internal/service/compose/service.go
@@ -21,10 +21,11 @@ type Service struct {
 
 // DeployRequest 部署请求
 type DeployRequest struct {
-	Content   string    `json:"content" binding:"required"` // compose.yml 文件内容（必填）
-	InitURL   string    `json:"initURL,omitempty"`          // 附加运行文件 zip 的下载地址（可选）
-	InitFile  io.Reader `json:"-"`                          // 附加运行文件（multipart 上传，不在 JSON 中）
-	ForcePull bool      `json:"forcePull,omitempty"`        // 是否强制拉取最新镜像
+	Content    string    `json:"content" binding:"required"` // compose.yml 文件内容（必填）
+	EnvContent string    `json:"envContent,omitempty"`        // 附加 .env 内容（KEY=VALUE），合并进插值环境并写盘
+	InitURL    string    `json:"initURL,omitempty"`           // 附加运行文件 zip 的下载地址（可选）
+	InitFile   io.Reader `json:"-"`                           // 附加运行文件（multipart 上传，不在 JSON 中）
+	ForcePull  bool      `json:"forcePull,omitempty"`         // 是否强制拉取最新镜像
 }
 
 // DeployResult 部署结果
@@ -37,6 +38,7 @@ type DeployResult struct {
 // ContentResult Compose 配置读取结果。
 type ContentResult struct {
 	Content     string `json:"content"`               // compose.yml 文本
+	EnvContent  string `json:"envContent,omitempty"`  // .env 文本（KEY=VALUE）；无落盘文件时为空
 	ProjectName string `json:"projectName,omitempty"` // 实际解析到的项目名
 	FileModTime int64  `json:"fileModTime,omitempty"` // compose.yml 修改时间戳（Unix 秒）；无落盘文件时为空
 	Source      string `json:"source,omitempty"`      // 内容来源：file=落盘文件，runtime=运行态反推
@@ -44,9 +46,11 @@ type ContentResult struct {
 
 // RedeployRequest 重建请求
 // - ServiceName + Image 非空：从现有内容读取后更新指定服务镜像重建
-// - 否则：Content 必须非空，全量重建
+// - 否则：Content 非空时全量重建（compose 与 .env 均可用新内容替换）
+// - EnvContent 单独变更：Content 可省略，仅更新 .env 后重建
 type RedeployRequest struct {
-	Content     string `json:"content,omitempty"`     // compose.yml 内容（未指定 serviceName 时必填，用于全量重建）
+	Content     string `json:"content,omitempty"`     // compose.yml 内容（未指定 serviceName 时与 envContent 至少其一必填，用于全量重建）
+	EnvContent  string `json:"envContent,omitempty"`  // .env 内容（可单独变更，与 content 一起更新时生效）
 	ServiceName string `json:"serviceName,omitempty"` // 目标服务名（与 image 配合，仅更新该服务镜像后重建）
 	Image       string `json:"image,omitempty"`       // 新镜像（指定 serviceName 时必填）
 	ForcePull   bool   `json:"forcePull,omitempty"`   // 是否强制拉取最新镜像
@@ -57,8 +61,11 @@ func (r RedeployRequest) Validate() error {
 	if r.ServiceName != "" && r.Image == "" {
 		return fmt.Errorf("指定服务名时 image 不能为空")
 	}
-	if r.ServiceName == "" && r.Content == "" {
-		return fmt.Errorf("未指定服务名时 content 不能为空")
+	if r.ServiceName != "" && r.Content != "" {
+		return fmt.Errorf("指定服务名时不能同时提交 content")
+	}
+	if r.ServiceName == "" && r.Content == "" && r.EnvContent == "" {
+		return fmt.Errorf("未指定服务名时 content 或 envContent 至少一项不能为空")
 	}
 	return nil
 }

--- a/internal/service/compose/swarm.go
+++ b/internal/service/compose/swarm.go
@@ -20,13 +20,14 @@ func (s *Service) SwarmDeploy(ctx context.Context, req DeployRequest) (*DeployRe
 		return nil, fmt.Errorf("未配置容器数据根目录")
 	}
 
-	// 项目名探测：浅解析提取顶层 name，不做完整 compose 解析（不解析 env_file），
-	// 避免在 .env 尚未写盘时报 env file not found
-	projectName, err := compose.ProjectNameFromContentShallow(ctx, req.Content, req.EnvContent)
+	// 部署前预检：不解析 env_file（避免 .env 尚未写盘时报错），
+	// 返回的 project.Name 已插值+规范化；无 name 时已用内容短哈希兜底
+	pre, err := compose.ProjectValidateWithoutEnvFiles(ctx, req.Content, req.EnvContent)
 	if err != nil {
 		return nil, err
 	}
-	if err := compose.ProjectValidateWithoutEnvFiles(ctx, projectName, req.Content, req.EnvContent); err != nil {
+	projectName, err := compose.ProjectNameFromProject(pre, req.Content)
+	if err != nil {
 		return nil, err
 	}
 

--- a/internal/service/compose/swarm.go
+++ b/internal/service/compose/swarm.go
@@ -52,6 +52,9 @@ func (s *Service) SwarmDeploy(ctx context.Context, req DeployRequest) (*DeployRe
 		return nil, err
 	}
 
+	// 写 .env（显式内容优先；附加文件解压的 .env 已存在则保留，否则兜底空文件）
+	compose.EnvSave(installDir, req.EnvContent, "")
+
 	project, err = compose.ProjectLoad(ctx, projectName, req.Content, installDir)
 	if err != nil {
 		return nil, err
@@ -104,7 +107,13 @@ func (s *Service) SwarmContentResult(ctx context.Context, name string, forceRunt
 	fileModTime := composeFileModTime(path)
 	if !forceRuntime {
 		if data, err := os.ReadFile(path); err == nil {
-			return &ContentResult{Content: string(data), ProjectName: name, FileModTime: fileModTime, Source: "file"}, nil
+			return &ContentResult{
+				Content:     string(data),
+				EnvContent:  compose.EnvContentRead(filepath.Join(root, name)),
+				ProjectName: name,
+				FileModTime: fileModTime,
+				Source:      "file",
+			}, nil
 		}
 	}
 
@@ -120,12 +129,19 @@ func (s *Service) SwarmContentResult(ctx context.Context, name string, forceRunt
 	if err != nil {
 		return nil, err
 	}
-	return &ContentResult{Content: string(data), ProjectName: name, FileModTime: fileModTime, Source: "runtime"}, nil
+	return &ContentResult{
+		Content:     string(data),
+		EnvContent:  compose.EnvContentRead(filepath.Join(root, name)),
+		ProjectName: name,
+		FileModTime: fileModTime,
+		Source:      "runtime",
+	}, nil
 }
 
 // SwarmRedeploy 重建 Swarm Compose 项目。
-// req.ServiceName + req.Image 非空时：仅更新指定服务的镜像后全量重建；
-// 否则：用 req.Content 全量重建。
+// - ServiceName+Image 非空：仅更新指定服务的镜像后全量重建
+// - EnvContent 单独非空（Content 为空）：仅更新 .env 后重建
+// - Content 非空：全量重建（compose 与 .env 均可替换）
 func (s *Service) SwarmRedeploy(ctx context.Context, name string, req RedeployRequest) (*DeployResult, error) {
 	if err := compose.ValidateProjectName(name); err != nil {
 		return nil, err
@@ -140,7 +156,9 @@ func (s *Service) SwarmRedeploy(ctx context.Context, name string, req RedeployRe
 		installDir = filepath.Join(root, name)
 	}
 
-	// 准备新 content：单服务镜像更新 or 全量替换
+	oldEnv := compose.EnvContentRead(installDir)
+
+	// 准备新 content：单服务镜像更新 or 全量替换 or 仅 .env
 	content := req.Content
 	if req.ServiceName != "" {
 		oldContent, err := s.SwarmContent(ctx, name)
@@ -154,9 +172,12 @@ func (s *Service) SwarmRedeploy(ctx context.Context, name string, req RedeployRe
 	}
 
 	oldContent, _ := s.SwarmContent(ctx, name)
+	if content == "" {
+		content = oldContent
+	}
 
 	// 先解析新 content 校验合法性（不写文件、不删旧实例），失败时旧服务保持运行
-	newProject, err := compose.ProjectParse(ctx, name, content, installDir)
+	newProject, err := compose.LoadProjectFromContentWithEnv(ctx, content, installDir, name, req.EnvContent)
 	if err != nil {
 		return nil, err
 	}
@@ -173,6 +194,7 @@ func (s *Service) SwarmRedeploy(ctx context.Context, name string, req RedeployRe
 	rollback := func() {
 		s.swarmRollback(ctx, name, oldContent, installDir)
 		compose.ContentSave(installDir, oldContent, "")
+		compose.EnvSave(installDir, oldEnv, "")
 	}
 
 	project, err := compose.ProjectLoad(ctx, name, content, installDir)
@@ -188,6 +210,7 @@ func (s *Service) SwarmRedeploy(ctx context.Context, name string, req RedeployRe
 	}
 
 	compose.ContentSave(installDir, content, oldContent)
+	compose.EnvSave(installDir, req.EnvContent, oldEnv)
 
 	logman.Info("Swarm compose redeployed", "name", name)
 	return &DeployResult{ProjectName: name, Items: items, InstallDir: installDir}, nil

--- a/internal/service/compose/swarm.go
+++ b/internal/service/compose/swarm.go
@@ -66,8 +66,12 @@ func (s *Service) SwarmDeploy(ctx context.Context, req DeployRequest) (*DeployRe
 		return nil, err
 	}
 
-	// 写 .env（显式内容优先；附加文件解压的 .env 已存在则保留，否则兜底空文件）
-	if err := compose.EnvSave(installDir, req.EnvContent, ""); err != nil {
+	// 写 .env：显式提交则以其为准（空串即清空），未提交则保留附加文件解压出的 .env 并兜底空文件
+	if req.EnvContent != nil {
+		if err := compose.EnvSave(installDir, *req.EnvContent, ""); err != nil {
+			return nil, err
+		}
+	} else if err := compose.EnvEnsure(installDir); err != nil {
 		return nil, err
 	}
 
@@ -155,9 +159,10 @@ func (s *Service) SwarmContentResult(ctx context.Context, name string, forceRunt
 }
 
 // SwarmRedeploy 重建 Swarm Compose 项目。
-// - ServiceName+Image 非空：仅更新指定服务的镜像后全量重建
-// - EnvContent 单独非空（Content 为空）：仅更新 .env 后重建
-// - Content 非空：全量重建（compose 与 .env 均可替换）
+// 部分更新：提交哪个字段就改哪个字段，未提交的字段保持不变。
+// - ServiceName+Image：仅更新指定服务的镜像后全量重建
+// - Content：替换 compose.yml 后重建
+// - EnvContent：替换 .env（空串即清空）后重建
 func (s *Service) SwarmRedeploy(ctx context.Context, name string, req RedeployRequest) (*DeployResult, error) {
 	if err := compose.ValidateProjectName(name); err != nil {
 		return nil, err
@@ -178,22 +183,26 @@ func (s *Service) SwarmRedeploy(ctx context.Context, name string, req RedeployRe
 	}
 	oldEnv := oldEnvState.Content
 
-	// 准备新 content：单服务镜像更新 or 全量替换 or 仅 .env
-	content := req.Content
-	if req.ServiceName != "" {
-		oldContent, err := s.SwarmContent(ctx, name)
-		if err != nil {
-			return nil, err
+	oldContent, contentErr := s.SwarmContent(ctx, name)
+
+	// 准备新 content：未提交则沿用现有 compose 内容
+	content := oldContent
+	switch {
+	case req.ServiceName != "":
+		if contentErr != nil {
+			return nil, contentErr
 		}
 		content, err = compose.UpdateServiceImage(ctx, name, oldContent, req.ServiceName, req.Image)
 		if err != nil {
 			return nil, err
 		}
-	}
-
-	oldContent, _ := s.SwarmContent(ctx, name)
-	if content == "" {
-		content = oldContent
+	case req.Content != nil:
+		content = *req.Content
+	default:
+		// 仅更新 .env：必须能读到现有 compose 内容
+		if contentErr != nil {
+			return nil, contentErr
+		}
 	}
 
 	// 先解析新 content 校验合法性（不写文件、不删旧实例），失败时旧服务保持运行
@@ -222,7 +231,12 @@ func (s *Service) SwarmRedeploy(ctx context.Context, name string, req RedeployRe
 	}
 
 	// 先落盘新 .env，确保 ProjectLoad 插值读取到新值（与 Deploy 流程顺序一致）
-	if err := compose.EnvSave(installDir, req.EnvContent, oldEnv); err != nil {
+	if req.EnvContent != nil {
+		if err := compose.EnvSave(installDir, *req.EnvContent, oldEnv); err != nil {
+			rollback()
+			return nil, err
+		}
+	} else if err := compose.EnvEnsure(installDir); err != nil {
 		rollback()
 		return nil, err
 	}

--- a/internal/service/compose/swarm.go
+++ b/internal/service/compose/swarm.go
@@ -127,9 +127,13 @@ func (s *Service) SwarmContentResult(ctx context.Context, name string, forceRunt
 	fileModTime := composeFileModTime(path)
 	if !forceRuntime {
 		if data, err := os.ReadFile(path); err == nil {
+			envContent, err := compose.EnvContentRead(filepath.Join(root, name))
+			if err != nil {
+				return nil, err
+			}
 			return &ContentResult{
 				Content:     string(data),
-				EnvContent:  compose.EnvContentRead(filepath.Join(root, name)),
+				EnvContent:  envContent,
 				ProjectName: name,
 				FileModTime: fileModTime,
 				Source:      "file",
@@ -149,9 +153,13 @@ func (s *Service) SwarmContentResult(ctx context.Context, name string, forceRunt
 	if err != nil {
 		return nil, err
 	}
+	envContent, err := compose.EnvContentRead(filepath.Join(root, name))
+	if err != nil {
+		return nil, err
+	}
 	return &ContentResult{
 		Content:     string(data),
-		EnvContent:  compose.EnvContentRead(filepath.Join(root, name)),
+		EnvContent:  envContent,
 		ProjectName: name,
 		FileModTime: fileModTime,
 		Source:      "runtime",
@@ -220,37 +228,37 @@ func (s *Service) SwarmRedeploy(ctx context.Context, name string, req RedeployRe
 
 	s.swarmServicesRemove(ctx, name, oldContent)
 
-	rollback := func() {
-		// 先恢复旧 .env 再回滚服务，确保回滚服务使用旧环境变量
+	rollback := func() string {
+		// 先恢复旧 .env 再回滚服务；.env 失败不阻断服务回滚
 		compose.ContentSave(installDir, oldContent, "")
-		if err := compose.EnvStateRestore(installDir, oldEnvState); err != nil {
-			logman.Warn("Restore swarm compose env before rollback failed", "name", name, "error", err)
-			return
+		envErr := compose.EnvStateRestore(installDir, oldEnvState)
+		if envErr != nil {
+			logman.Warn("Restore swarm compose env before rollback failed", "name", name, "error", envErr)
 		}
-		s.swarmRollback(ctx, name, oldContent, installDir)
+		runtimeErr := s.swarmRollback(ctx, name, oldContent, installDir)
+		if runtimeErr != nil {
+			logman.Warn("Rollback swarm services failed", "name", name, "error", runtimeErr)
+		}
+		return formatRedeployRollbackSummary(envErr == nil, envErr, runtimeErr == nil, runtimeErr, "服务")
 	}
 
 	// 先落盘新 .env，确保 ProjectLoad 插值读取到新值（与 Deploy 流程顺序一致）
 	if req.EnvContent != nil {
 		if err := compose.EnvSave(installDir, *req.EnvContent, oldEnv); err != nil {
-			rollback()
-			return nil, err
+			return nil, wrapRedeployError(err, rollback())
 		}
 	} else if err := compose.EnvEnsure(installDir); err != nil {
-		rollback()
-		return nil, err
+		return nil, wrapRedeployError(err, rollback())
 	}
 
 	project, err := compose.ProjectLoad(ctx, name, content, installDir)
 	if err != nil {
-		rollback()
-		return nil, err
+		return nil, wrapRedeployError(err, rollback())
 	}
 
 	items, err := s.swarmServicesCreate(ctx, project)
 	if err != nil {
-		rollback()
-		return nil, err
+		return nil, wrapRedeployError(err, rollback())
 	}
 
 	compose.ContentSave(installDir, content, oldContent)
@@ -321,18 +329,18 @@ func (s *Service) swarmServicesRemove(ctx context.Context, name, content string)
 }
 
 // swarmRollback 用指定配置内容重建 Swarm 服务（回滚用）
-func (s *Service) swarmRollback(ctx context.Context, name, content, installDir string) {
+func (s *Service) swarmRollback(ctx context.Context, name, content, installDir string) error {
 	if content == "" {
-		return
+		return fmt.Errorf("无可回滚的 compose 内容")
 	}
 	project, err := compose.ProjectParse(ctx, name, content, installDir)
 	if err != nil {
-		logman.Warn("Rollback load project failed", "name", name, "error", err)
-		return
+		return fmt.Errorf("加载回滚配置失败: %w", err)
 	}
 	if _, err := s.swarmServicesCreate(ctx, project); err != nil {
-		logman.Warn("Rollback deploy failed", "name", name, "error", err)
+		return fmt.Errorf("重建服务失败: %w", err)
 	}
+	return nil
 }
 
 // swarmEnsureNetworks 确保 project 中所有非 external 的网络以 overlay driver 存在

--- a/internal/service/compose/swarm.go
+++ b/internal/service/compose/swarm.go
@@ -20,11 +20,9 @@ func (s *Service) SwarmDeploy(ctx context.Context, req DeployRequest) (*DeployRe
 		return nil, fmt.Errorf("未配置容器数据根目录")
 	}
 
-	project, err := compose.LoadProjectFromContent(ctx, req.Content, "")
-	if err != nil {
-		return nil, err
-	}
-	projectName, err := compose.ProjectNameFromProject(project, req.Content)
+	// 项目名探测：浅解析提取顶层 name，不做完整 compose 解析（不解析 env_file），
+	// 避免在 .env 尚未写盘时报 env file not found
+	projectName, err := compose.ProjectNameFromContentShallow(req.Content)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +53,7 @@ func (s *Service) SwarmDeploy(ctx context.Context, req DeployRequest) (*DeployRe
 	// 写 .env（显式内容优先；附加文件解压的 .env 已存在则保留，否则兜底空文件）
 	compose.EnvSave(installDir, req.EnvContent, "")
 
-	project, err = compose.ProjectLoad(ctx, projectName, req.Content, installDir)
+	project, err := compose.ProjectLoad(ctx, projectName, req.Content, installDir)
 	if err != nil {
 		return nil, err
 	}
@@ -192,10 +190,14 @@ func (s *Service) SwarmRedeploy(ctx context.Context, name string, req RedeployRe
 	s.swarmServicesRemove(ctx, name, oldContent)
 
 	rollback := func() {
-		s.swarmRollback(ctx, name, oldContent, installDir)
+		// 先恢复旧 .env 再回滚服务，确保回滚服务使用旧环境变量
 		compose.ContentSave(installDir, oldContent, "")
 		compose.EnvSave(installDir, oldEnv, "")
+		s.swarmRollback(ctx, name, oldContent, installDir)
 	}
+
+	// 先落盘新 .env，确保 ProjectLoad 插值读取到新值（与 Deploy 流程顺序一致）
+	compose.EnvSave(installDir, req.EnvContent, oldEnv)
 
 	project, err := compose.ProjectLoad(ctx, name, content, installDir)
 	if err != nil {
@@ -210,7 +212,6 @@ func (s *Service) SwarmRedeploy(ctx context.Context, name string, req RedeployRe
 	}
 
 	compose.ContentSave(installDir, content, oldContent)
-	compose.EnvSave(installDir, req.EnvContent, oldEnv)
 
 	logman.Info("Swarm compose redeployed", "name", name)
 	return &DeployResult{ProjectName: name, Items: items, InstallDir: installDir}, nil

--- a/internal/service/compose/swarm.go
+++ b/internal/service/compose/swarm.go
@@ -22,8 +22,11 @@ func (s *Service) SwarmDeploy(ctx context.Context, req DeployRequest) (*DeployRe
 
 	// 项目名探测：浅解析提取顶层 name，不做完整 compose 解析（不解析 env_file），
 	// 避免在 .env 尚未写盘时报 env file not found
-	projectName, err := compose.ProjectNameFromContentShallow(req.Content)
+	projectName, err := compose.ProjectNameFromContentShallow(ctx, req.Content, req.EnvContent)
 	if err != nil {
+		return nil, err
+	}
+	if err := compose.ProjectValidateWithoutEnvFiles(ctx, projectName, req.Content, req.EnvContent); err != nil {
 		return nil, err
 	}
 
@@ -35,11 +38,23 @@ func (s *Service) SwarmDeploy(ctx context.Context, req DeployRequest) (*DeployRe
 
 	_, err = os.Stat(installDir)
 	installDirExists := err == nil
+	initialEnvState, err := compose.EnvStateRead(installDir)
+	if err != nil {
+		return nil, err
+	}
 
 	deployed := false
 	defer func() {
-		if !deployed && !installDirExists {
+		if deployed {
+			return
+		}
+		if !installDirExists {
 			_ = os.RemoveAll(installDir)
+			return
+		}
+		_ = os.Remove(composeFile)
+		if err := compose.EnvStateRestore(installDir, initialEnvState); err != nil {
+			logman.Warn("Restore swarm compose env after failed deploy", "name", projectName, "error", err)
 		}
 	}()
 
@@ -51,7 +66,9 @@ func (s *Service) SwarmDeploy(ctx context.Context, req DeployRequest) (*DeployRe
 	}
 
 	// 写 .env（显式内容优先；附加文件解压的 .env 已存在则保留，否则兜底空文件）
-	compose.EnvSave(installDir, req.EnvContent, "")
+	if err := compose.EnvSave(installDir, req.EnvContent, ""); err != nil {
+		return nil, err
+	}
 
 	project, err := compose.ProjectLoad(ctx, projectName, req.Content, installDir)
 	if err != nil {
@@ -154,7 +171,11 @@ func (s *Service) SwarmRedeploy(ctx context.Context, name string, req RedeployRe
 		installDir = filepath.Join(root, name)
 	}
 
-	oldEnv := compose.EnvContentRead(installDir)
+	oldEnvState, err := compose.EnvStateRead(installDir)
+	if err != nil {
+		return nil, err
+	}
+	oldEnv := oldEnvState.Content
 
 	// 准备新 content：单服务镜像更新 or 全量替换 or 仅 .env
 	content := req.Content
@@ -192,12 +213,18 @@ func (s *Service) SwarmRedeploy(ctx context.Context, name string, req RedeployRe
 	rollback := func() {
 		// 先恢复旧 .env 再回滚服务，确保回滚服务使用旧环境变量
 		compose.ContentSave(installDir, oldContent, "")
-		compose.EnvSave(installDir, oldEnv, "")
+		if err := compose.EnvStateRestore(installDir, oldEnvState); err != nil {
+			logman.Warn("Restore swarm compose env before rollback failed", "name", name, "error", err)
+			return
+		}
 		s.swarmRollback(ctx, name, oldContent, installDir)
 	}
 
 	// 先落盘新 .env，确保 ProjectLoad 插值读取到新值（与 Deploy 流程顺序一致）
-	compose.EnvSave(installDir, req.EnvContent, oldEnv)
+	if err := compose.EnvSave(installDir, req.EnvContent, oldEnv); err != nil {
+		rollback()
+		return nil, err
+	}
 
 	project, err := compose.ProjectLoad(ctx, name, content, installDir)
 	if err != nil {

--- a/pkgs/compose/project.go
+++ b/pkgs/compose/project.go
@@ -167,27 +167,39 @@ func loadProjectWithOptions(ctx context.Context, details types.ConfigDetails, pr
 	return project, nil
 }
 
-// ProjectValidateWithoutEnvFiles 在不读取 services.env_file 的前提下校验 Compose 结构。
+// ProjectValidateWithoutEnvFiles 在不读取 services.env_file 的前提下校验 Compose 结构，
+// 返回解析结果供调用方复用（如项目名，已插值+规范化；无 name 时用内容短哈希兜底）。
 // 用于部署落盘前预检；env_file 仅在文件就位后的正式加载阶段解析。
-func ProjectValidateWithoutEnvFiles(ctx context.Context, projectName, content, envContent string) error {
+func ProjectValidateWithoutEnvFiles(ctx context.Context, content, envContent string) (*types.Project, error) {
 	if content == "" {
-		return fmt.Errorf("compose 内容为空")
+		return nil, fmt.Errorf("compose 内容为空")
 	}
 	env, err := projectEnvironmentWithEnvFile(ctx, nil, envContent, "")
 	if err != nil {
-		return err
+		return nil, err
 	}
-	_, err = loadProjectWithOptions(ctx, types.ConfigDetails{
+	details := types.ConfigDetails{
 		WorkingDir: ".",
 		ConfigFiles: []types.ConfigFile{{
 			Filename: "compose.yml",
 			Content:  []byte(content),
 		}},
 		Environment: env,
-	}, projectName, false, true, func(o *loader.Options) {
+	}
+	project, err := loadProjectWithOptions(ctx, details, "", false, false, func(o *loader.Options) {
 		o.SkipResolveEnvironment = true
 	})
-	return err
+	if err != nil {
+		// 无顶层 name 时 loader 报空名错误，用内容短哈希兜底
+		hash := ShortHash(content)
+		project, err = loadProjectWithOptions(ctx, details, hash, false, true, func(o *loader.Options) {
+			o.SkipResolveEnvironment = true
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	return project, nil
 }
 
 func projectEnvironment(extra map[string]string) map[string]string {

--- a/pkgs/compose/project.go
+++ b/pkgs/compose/project.go
@@ -145,6 +145,10 @@ func loadProjectFromContentWithEnv(ctx context.Context, content, workingDir, pro
 }
 
 func loadProject(ctx context.Context, details types.ConfigDetails, projectName string, resolvePaths bool, setProjectName bool) (*types.Project, error) {
+	return loadProjectWithOptions(ctx, details, projectName, resolvePaths, setProjectName, nil)
+}
+
+func loadProjectWithOptions(ctx context.Context, details types.ConfigDetails, projectName string, resolvePaths bool, setProjectName bool, configure func(*loader.Options)) (*types.Project, error) {
 	projectName = loader.NormalizeProjectName(projectName)
 	project, err := loader.LoadWithContext(ctx, details, func(o *loader.Options) {
 		if setProjectName && projectName != "" {
@@ -153,11 +157,37 @@ func loadProject(ctx context.Context, details types.ConfigDetails, projectName s
 		o.SkipConsistencyCheck = false
 		o.SkipValidation = false
 		o.ResolvePaths = resolvePaths
+		if configure != nil {
+			configure(o)
+		}
 	})
 	if err != nil {
 		return nil, fmt.Errorf("加载 compose 失败: %w", err)
 	}
 	return project, nil
+}
+
+// ProjectValidateWithoutEnvFiles 在不读取 services.env_file 的前提下校验 Compose 结构。
+// 用于部署落盘前预检；env_file 仅在文件就位后的正式加载阶段解析。
+func ProjectValidateWithoutEnvFiles(ctx context.Context, projectName, content, envContent string) error {
+	if content == "" {
+		return fmt.Errorf("compose 内容为空")
+	}
+	env, err := projectEnvironmentWithEnvFile(ctx, nil, envContent, "")
+	if err != nil {
+		return err
+	}
+	_, err = loadProjectWithOptions(ctx, types.ConfigDetails{
+		WorkingDir: ".",
+		ConfigFiles: []types.ConfigFile{{
+			Filename: "compose.yml",
+			Content:  []byte(content),
+		}},
+		Environment: env,
+	}, projectName, false, true, func(o *loader.Options) {
+		o.SkipResolveEnvironment = true
+	})
+	return err
 }
 
 func projectEnvironment(extra map[string]string) map[string]string {

--- a/pkgs/compose/project.go
+++ b/pkgs/compose/project.go
@@ -6,12 +6,16 @@
 package compose
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"log/slog"
 	"maps"
 	"os"
 	"path/filepath"
+	"strings"
 
+	"github.com/compose-spec/compose-go/v2/dotenv"
 	"github.com/compose-spec/compose-go/v2/loader"
 	"github.com/compose-spec/compose-go/v2/types"
 )
@@ -42,6 +46,7 @@ type LoadOptions struct {
 	ConfigFiles []string          // 指定要加载的 compose 文件绝对路径；为空则在 WorkingDir 下自动查找
 	ProjectName string            // 项目名（影响生成的网络/容器默认前缀）
 	Environment map[string]string // 额外的环境变量（会与 .env 合并，优先级更高）
+	EnvContent  string            // 附加的 .env 内容（KEY=VALUE），解析后合并进插值环境；为空则尝试读取 WorkingDir/.env
 }
 
 // LoadProject 使用 compose-go 官方加载器解析 compose 文件，
@@ -65,10 +70,15 @@ func LoadProject(ctx context.Context, opts LoadOptions) (*types.Project, error) 
 		projectName = filepath.Base(opts.WorkingDir)
 	}
 
+	env, err := projectEnvironmentWithEnvFile(ctx, opts.Environment, opts.EnvContent, opts.WorkingDir)
+	if err != nil {
+		return nil, err
+	}
+
 	return loadProject(ctx, types.ConfigDetails{
 		WorkingDir:  opts.WorkingDir,
 		ConfigFiles: files,
-		Environment: projectEnvironment(opts.Environment),
+		Environment: env,
 	}, projectName, true, true)
 }
 
@@ -90,6 +100,11 @@ func loadProjectFromContent(ctx context.Context, content, workingDir, projectNam
 		return nil, fmt.Errorf("compose 内容为空")
 	}
 
+	env, err := projectEnvironmentWithEnvFile(ctx, nil, "", workingDir)
+	if err != nil {
+		return nil, err
+	}
+
 	details := types.ConfigDetails{
 		WorkingDir: workingDir,
 		ConfigFiles: []types.ConfigFile{
@@ -98,7 +113,32 @@ func loadProjectFromContent(ctx context.Context, content, workingDir, projectNam
 				Content:  []byte(content),
 			},
 		},
-		Environment: projectEnvironment(nil),
+		Environment: env,
+	}
+
+	return loadProject(ctx, details, projectName, resolvePaths, projectName != "")
+}
+
+// loadProjectFromContentWithEnv 从 yaml 文本加载 compose 项目，并额外合并指定的 .env 内容到插值环境。
+func loadProjectFromContentWithEnv(ctx context.Context, content, workingDir, projectName, envContent string, resolvePaths bool) (*types.Project, error) {
+	if content == "" {
+		return nil, fmt.Errorf("compose 内容为空")
+	}
+
+	env, err := projectEnvironmentWithEnvFile(ctx, nil, envContent, workingDir)
+	if err != nil {
+		return nil, err
+	}
+
+	details := types.ConfigDetails{
+		WorkingDir: workingDir,
+		ConfigFiles: []types.ConfigFile{
+			{
+				Filename: "compose.yml",
+				Content:  []byte(content),
+			},
+		},
+		Environment: env,
 	}
 
 	return loadProject(ctx, details, projectName, resolvePaths, projectName != "")
@@ -132,6 +172,42 @@ func projectEnvironment(extra map[string]string) map[string]string {
 	}
 	maps.Copy(env, extra)
 	return env
+}
+
+// projectEnvironmentWithEnvFile 构建插值环境：进程环境 + 显式 envContent + WorkingDir/.env 文件。
+// 优先级从低到高：进程环境 < WorkingDir/.env 文件 < envContent（显式传入的 .env 内容）。
+func projectEnvironmentWithEnvFile(ctx context.Context, extra map[string]string, envContent, workingDir string) (map[string]string, error) {
+	env := projectEnvironment(extra)
+
+	// 读取 WorkingDir 下已存在的 .env 文件（对齐 docker compose 行为）
+	if workingDir != "" {
+		envFilePath := filepath.Join(workingDir, ".env")
+		if data, err := os.ReadFile(envFilePath); err == nil {
+			fileEnv, perr := parseEnvContent(string(data))
+			if perr != nil {
+				return nil, fmt.Errorf("解析 %s 失败: %w", envFilePath, perr)
+			}
+			maps.Copy(env, fileEnv)
+		} else if !os.IsNotExist(err) {
+			slog.DebugContext(ctx, "read project .env failed", "path", envFilePath, "error", err)
+		}
+	}
+
+	// 显式传入的 .env 内容优先级最高
+	if strings.TrimSpace(envContent) != "" {
+		fileEnv, perr := parseEnvContent(envContent)
+		if perr != nil {
+			return nil, fmt.Errorf("解析 .env 内容失败: %w", perr)
+		}
+		maps.Copy(env, fileEnv)
+	}
+
+	return env, nil
+}
+
+// parseEnvContent 解析 KEY=VALUE 形式的 .env 文本。
+func parseEnvContent(content string) (map[string]string, error) {
+	return dotenv.Parse(bytes.NewReader([]byte(content)))
 }
 func resolveConfigFiles(workingDir string, configFiles []string) ([]string, error) {
 	if len(configFiles) > 0 {
@@ -185,4 +261,13 @@ func findComposeFile(dir string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+// LoadProjectFromContentWithEnv 从 yaml 文本加载 compose 项目，并显式合并指定 .env 内容到插值环境。
+// workingDir 用于解析相对路径；envContent 为空时回退读取 workingDir/.env 文件。
+func LoadProjectFromContentWithEnv(ctx context.Context, content, workingDir, projectName, envContent string) (*types.Project, error) {
+	if workingDir == "" {
+		workingDir = "."
+	}
+	return loadProjectFromContentWithEnv(ctx, content, workingDir, projectName, envContent, true)
 }

--- a/pkgs/compose/project.go
+++ b/pkgs/compose/project.go
@@ -46,7 +46,7 @@ type LoadOptions struct {
 	WorkingDir  string            // compose 文件所在目录（用于解析相对路径和 .env）
 	ConfigFiles []string          // 指定要加载的 compose 文件绝对路径；为空则在 WorkingDir 下自动查找
 	ProjectName string            // 项目名（影响生成的网络/容器默认前缀）
-	Environment map[string]string // 额外的环境变量（优先级高于进程环境，低于 .env）
+	Environment map[string]string // 额外的环境变量（并入进程环境，优先级高于 .env）
 }
 
 // LoadProject 使用 compose-go 官方加载器解析 compose 文件，
@@ -222,24 +222,8 @@ func projectEnvironment(extra map[string]string) map[string]string {
 }
 
 // projectEnvironmentWithEnvFile 构建 ${VAR} 插值环境。
-// envContent 非 nil 时以其为准（空串表示无任何变量），不再读取 workingDir/.env；
-// envContent 为 nil 时回退读取 workingDir/.env。
-// 优先级从低到高：进程环境 < extra < .env（显式内容或 workingDir/.env）。
-// 注意：此处 .env 覆盖进程环境，与 docker compose（shell 覆盖 .env）相反，
-// 目的是让用户在界面上编辑的 .env 始终是权威来源。
 func projectEnvironmentWithEnvFile(ctx context.Context, extra map[string]string, envContent *string, workingDir string) (map[string]string, error) {
-	env := projectEnvironment(extra)
-
-	if envContent != nil {
-		if strings.TrimSpace(*envContent) != "" {
-			fileEnv, err := parseEnvContent(*envContent)
-			if err != nil {
-				return nil, fmt.Errorf("解析 .env 内容失败: %w", err)
-			}
-			maps.Copy(env, fileEnv)
-		}
-		return env, nil
-	}
+	env := make(map[string]string)
 
 	if workingDir != "" {
 		envFilePath := filepath.Join(workingDir, EnvFileName)
@@ -253,6 +237,16 @@ func projectEnvironmentWithEnvFile(ctx context.Context, extra map[string]string,
 			slog.DebugContext(ctx, "read project .env failed", "path", envFilePath, "error", err)
 		}
 	}
+
+	if envContent != nil && strings.TrimSpace(*envContent) != "" {
+		fileEnv, err := parseEnvContent(*envContent)
+		if err != nil {
+			return nil, fmt.Errorf("解析 .env 内容失败: %w", err)
+		}
+		maps.Copy(env, fileEnv)
+	}
+
+	maps.Copy(env, projectEnvironment(extra))
 
 	return env, nil
 }
@@ -316,7 +310,7 @@ func findComposeFile(dir string) (string, bool) {
 }
 
 // LoadProjectFromContentWithEnv 从 yaml 文本加载 compose 项目，并显式合并指定 .env 内容到插值环境。
-// workingDir 用于解析相对路径；envContent 为 nil 时回退读取 workingDir/.env；非 nil 时以其为准。
+// workingDir 用于解析相对路径；envContent 为 nil 时仅读 workingDir/.env；非 nil 时在磁盘 .env 之上叠加。
 func LoadProjectFromContentWithEnv(ctx context.Context, content, workingDir, projectName string, envContent *string) (*types.Project, error) {
 	if workingDir == "" {
 		workingDir = "."

--- a/pkgs/compose/project.go
+++ b/pkgs/compose/project.go
@@ -18,6 +18,7 @@ import (
 	"github.com/compose-spec/compose-go/v2/dotenv"
 	"github.com/compose-spec/compose-go/v2/loader"
 	"github.com/compose-spec/compose-go/v2/types"
+	"github.com/goccy/go-yaml"
 )
 
 // composeFileCandidates 常见的 compose 文件名（按优先级）
@@ -45,8 +46,7 @@ type LoadOptions struct {
 	WorkingDir  string            // compose 文件所在目录（用于解析相对路径和 .env）
 	ConfigFiles []string          // 指定要加载的 compose 文件绝对路径；为空则在 WorkingDir 下自动查找
 	ProjectName string            // 项目名（影响生成的网络/容器默认前缀）
-	Environment map[string]string // 额外的环境变量（会与 .env 合并，优先级更高）
-	EnvContent  string            // 附加的 .env 内容（KEY=VALUE），解析后合并进插值环境；为空则尝试读取 WorkingDir/.env
+	Environment map[string]string // 额外的环境变量（优先级高于进程环境，低于 .env）
 }
 
 // LoadProject 使用 compose-go 官方加载器解析 compose 文件，
@@ -70,7 +70,7 @@ func LoadProject(ctx context.Context, opts LoadOptions) (*types.Project, error) 
 		projectName = filepath.Base(opts.WorkingDir)
 	}
 
-	env, err := projectEnvironmentWithEnvFile(ctx, opts.Environment, opts.EnvContent, opts.WorkingDir)
+	env, err := projectEnvironmentWithEnvFile(ctx, opts.Environment, nil, opts.WorkingDir)
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +100,7 @@ func loadProjectFromContent(ctx context.Context, content, workingDir, projectNam
 		return nil, fmt.Errorf("compose 内容为空")
 	}
 
-	env, err := projectEnvironmentWithEnvFile(ctx, nil, "", workingDir)
+	env, err := projectEnvironmentWithEnvFile(ctx, nil, nil, workingDir)
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +120,7 @@ func loadProjectFromContent(ctx context.Context, content, workingDir, projectNam
 }
 
 // loadProjectFromContentWithEnv 从 yaml 文本加载 compose 项目，并额外合并指定的 .env 内容到插值环境。
-func loadProjectFromContentWithEnv(ctx context.Context, content, workingDir, projectName, envContent string, resolvePaths bool) (*types.Project, error) {
+func loadProjectFromContentWithEnv(ctx context.Context, content, workingDir, projectName string, envContent *string, resolvePaths bool) (*types.Project, error) {
 	if content == "" {
 		return nil, fmt.Errorf("compose 内容为空")
 	}
@@ -168,9 +168,9 @@ func loadProjectWithOptions(ctx context.Context, details types.ConfigDetails, pr
 }
 
 // ProjectValidateWithoutEnvFiles 在不读取 services.env_file 的前提下校验 Compose 结构，
-// 返回解析结果供调用方复用（如项目名，已插值+规范化；无 name 时用内容短哈希兜底）。
+// 返回解析结果供调用方复用（如项目名，已插值+规范化；未声明 name 时用内容短哈希兜底）。
 // 用于部署落盘前预检；env_file 仅在文件就位后的正式加载阶段解析。
-func ProjectValidateWithoutEnvFiles(ctx context.Context, content, envContent string) (*types.Project, error) {
+func ProjectValidateWithoutEnvFiles(ctx context.Context, content string, envContent *string) (*types.Project, error) {
 	if content == "" {
 		return nil, fmt.Errorf("compose 内容为空")
 	}
@@ -186,18 +186,23 @@ func ProjectValidateWithoutEnvFiles(ctx context.Context, content, envContent str
 		}},
 		Environment: env,
 	}
-	project, err := loadProjectWithOptions(ctx, details, "", false, false, func(o *loader.Options) {
+	skipEnvFiles := func(o *loader.Options) {
 		o.SkipResolveEnvironment = true
-	})
-	if err != nil {
-		// 无顶层 name 时 loader 报空名错误，用内容短哈希兜底
-		hash := ShortHash(content)
-		project, err = loadProjectWithOptions(ctx, details, hash, false, true, func(o *loader.Options) {
-			o.SkipResolveEnvironment = true
-		})
-		if err != nil {
-			return nil, err
-		}
+	}
+
+	project, err := loadProjectWithOptions(ctx, details, "", false, false, skipEnvFiles)
+	if err == nil {
+		return project, nil
+	}
+
+	// 首次失败可能仅因未声明顶层 name，此时用内容短哈希兜底。
+	// 但若声明了 name 却解析为空，说明插值变量未提供，必须报错而非静默改名。
+	if declaresProjectName(content) {
+		return nil, err
+	}
+	project, hashErr := loadProjectWithOptions(ctx, details, ShortHash(content), false, true, skipEnvFiles)
+	if hashErr != nil {
+		return nil, err
 	}
 	return project, nil
 }
@@ -216,14 +221,28 @@ func projectEnvironment(extra map[string]string) map[string]string {
 	return env
 }
 
-// projectEnvironmentWithEnvFile 构建插值环境：进程环境 + 显式 envContent + WorkingDir/.env 文件。
-// 优先级从低到高：进程环境 < WorkingDir/.env 文件 < envContent（显式传入的 .env 内容）。
-func projectEnvironmentWithEnvFile(ctx context.Context, extra map[string]string, envContent, workingDir string) (map[string]string, error) {
+// projectEnvironmentWithEnvFile 构建 ${VAR} 插值环境。
+// envContent 非 nil 时以其为准（空串表示无任何变量），不再读取 workingDir/.env；
+// envContent 为 nil 时回退读取 workingDir/.env。
+// 优先级从低到高：进程环境 < extra < .env（显式内容或 workingDir/.env）。
+// 注意：此处 .env 覆盖进程环境，与 docker compose（shell 覆盖 .env）相反，
+// 目的是让用户在界面上编辑的 .env 始终是权威来源。
+func projectEnvironmentWithEnvFile(ctx context.Context, extra map[string]string, envContent *string, workingDir string) (map[string]string, error) {
 	env := projectEnvironment(extra)
 
-	// 读取 WorkingDir 下已存在的 .env 文件（对齐 docker compose 行为）
+	if envContent != nil {
+		if strings.TrimSpace(*envContent) != "" {
+			fileEnv, err := parseEnvContent(*envContent)
+			if err != nil {
+				return nil, fmt.Errorf("解析 .env 内容失败: %w", err)
+			}
+			maps.Copy(env, fileEnv)
+		}
+		return env, nil
+	}
+
 	if workingDir != "" {
-		envFilePath := filepath.Join(workingDir, ".env")
+		envFilePath := filepath.Join(workingDir, EnvFileName)
 		if data, err := os.ReadFile(envFilePath); err == nil {
 			fileEnv, perr := parseEnvContent(string(data))
 			if perr != nil {
@@ -233,15 +252,6 @@ func projectEnvironmentWithEnvFile(ctx context.Context, extra map[string]string,
 		} else if !os.IsNotExist(err) {
 			slog.DebugContext(ctx, "read project .env failed", "path", envFilePath, "error", err)
 		}
-	}
-
-	// 显式传入的 .env 内容优先级最高
-	if strings.TrimSpace(envContent) != "" {
-		fileEnv, perr := parseEnvContent(envContent)
-		if perr != nil {
-			return nil, fmt.Errorf("解析 .env 内容失败: %w", perr)
-		}
-		maps.Copy(env, fileEnv)
 	}
 
 	return env, nil
@@ -306,10 +316,23 @@ func findComposeFile(dir string) (string, bool) {
 }
 
 // LoadProjectFromContentWithEnv 从 yaml 文本加载 compose 项目，并显式合并指定 .env 内容到插值环境。
-// workingDir 用于解析相对路径；envContent 为空时回退读取 workingDir/.env 文件。
-func LoadProjectFromContentWithEnv(ctx context.Context, content, workingDir, projectName, envContent string) (*types.Project, error) {
+// workingDir 用于解析相对路径；envContent 为 nil 时回退读取 workingDir/.env；非 nil 时以其为准。
+func LoadProjectFromContentWithEnv(ctx context.Context, content, workingDir, projectName string, envContent *string) (*types.Project, error) {
 	if workingDir == "" {
 		workingDir = "."
 	}
 	return loadProjectFromContentWithEnv(ctx, content, workingDir, projectName, envContent, true)
+}
+
+// ─── 辅助函数 ───
+
+// declaresProjectName 判断 compose 文本是否声明了顶层 name 键。
+func declaresProjectName(content string) bool {
+	var doc struct {
+		Name *string `yaml:"name"`
+	}
+	if err := yaml.Unmarshal([]byte(content), &doc); err != nil {
+		return false
+	}
+	return doc.Name != nil
 }

--- a/pkgs/compose/runtime.go
+++ b/pkgs/compose/runtime.go
@@ -15,7 +15,11 @@ import (
 	"github.com/rehiy/libgo/request"
 )
 
-const ComposeFileName = "compose.yml"
+const (
+	ComposeFileName = "compose.yml"
+	// EnvFileName 项目 .env 文件名。
+	EnvFileName = ".env"
+)
 
 var safeProjectName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.-]*$`)
 
@@ -100,10 +104,7 @@ func ContentSave(installDir, content, bak string) {
 	}
 }
 
-// EnvFileName 项目 .env 文件名。
-const EnvFileName = ".env"
-
-// EnvSave 持久化 .env；env 非空时写入，否则确保空 .env 文件存在（防止 env_file: .env 因缺文件报错）。
+// EnvSave 以 env 为准写入 .env，空串表示清空内容。
 // bak 非空时同时写 .env.bak。
 func EnvSave(installDir, env, bak string) error {
 	if installDir == "" {
@@ -112,24 +113,33 @@ func EnvSave(installDir, env, bak string) error {
 	if err := os.MkdirAll(installDir, 0755); err != nil {
 		return fmt.Errorf("创建环境文件目录失败: %w", err)
 	}
-	envPath := filepath.Join(installDir, EnvFileName)
-	if env != "" {
-		if err := os.WriteFile(envPath, []byte(env), 0644); err != nil {
-			return fmt.Errorf("写入 .env 失败: %w", err)
-		}
-	} else {
-		if _, err := os.Stat(envPath); os.IsNotExist(err) {
-			if err := os.WriteFile(envPath, []byte(""), 0644); err != nil {
-				return fmt.Errorf("创建 .env 失败: %w", err)
-			}
-		} else if err != nil {
-			return fmt.Errorf("检查 .env 失败: %w", err)
-		}
+	if err := os.WriteFile(filepath.Join(installDir, EnvFileName), []byte(env), 0644); err != nil {
+		return fmt.Errorf("写入 .env 失败: %w", err)
 	}
 	if bak != "" {
 		if err := os.WriteFile(filepath.Join(installDir, EnvFileName+".bak"), []byte(bak), 0644); err != nil {
 			return fmt.Errorf("写入 .env.bak 失败: %w", err)
 		}
+	}
+	return nil
+}
+
+// EnvEnsure 确保 .env 存在（防止 env_file: .env 因缺文件报错），不修改已有内容。
+func EnvEnsure(installDir string) error {
+	if installDir == "" {
+		return nil
+	}
+	if err := os.MkdirAll(installDir, 0755); err != nil {
+		return fmt.Errorf("创建环境文件目录失败: %w", err)
+	}
+	envPath := filepath.Join(installDir, EnvFileName)
+	if _, err := os.Stat(envPath); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("检查 .env 失败: %w", err)
+	}
+	if err := os.WriteFile(envPath, []byte(""), 0644); err != nil {
+		return fmt.Errorf("创建 .env 失败: %w", err)
 	}
 	return nil
 }

--- a/pkgs/compose/runtime.go
+++ b/pkgs/compose/runtime.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"regexp"
 
+	"github.com/compose-spec/compose-go/v2/interpolation"
+	"github.com/compose-spec/compose-go/v2/loader"
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/goccy/go-yaml"
@@ -41,7 +43,10 @@ func ProjectNameFromProject(project *types.Project, content string) (string, err
 	if project == nil {
 		return "", fmt.Errorf("project 为空")
 	}
-	name := project.Name
+	return projectNameOrHash(project.Name, content)
+}
+
+func projectNameOrHash(name, content string) (string, error) {
 	if name == "" || name == "." {
 		name = ShortHash(content)
 	}
@@ -61,19 +66,33 @@ func ContentProjectName(ctx context.Context, content string) (string, error) {
 }
 
 // ProjectNameFromContentShallow 用 YAML 浅解析提取顶层 name 字段，缺失时使用内容短哈希。
-// 与 LoadProjectFromContent 不同，它不做完整的 compose 解析（不解析 env_file / 插值），
-// 适用于「仅需拿到项目名」的探测场景，避免在 .env 尚未写盘时报 env file not found。
-func ProjectNameFromContentShallow(content string) (string, error) {
+// 它仅对 name 做插值和 compose-go 同款规范化，不解析 services/env_file。
+func ProjectNameFromContentShallow(ctx context.Context, content, envContent string) (string, error) {
 	var doc struct {
 		Name string `yaml:"name"`
 	}
 	if err := yaml.Unmarshal([]byte(content), &doc); err != nil {
 		return "", fmt.Errorf("解析 compose 失败: %w", err)
 	}
-	name := doc.Name
-	if name == "" || name == "." {
-		name = ShortHash(content)
+	if doc.Name == "" || doc.Name == "." {
+		return projectNameOrHash(doc.Name, content)
 	}
+
+	env, err := projectEnvironmentWithEnvFile(ctx, nil, envContent, "")
+	if err != nil {
+		return "", err
+	}
+	result, err := interpolation.Interpolate(map[string]any{"name": doc.Name}, interpolation.Options{
+		LookupValue: func(key string) (string, bool) {
+			value, ok := env[key]
+			return value, ok
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("解析 compose 项目名失败: %w", err)
+	}
+	name, _ := result["name"].(string)
+	name = loader.NormalizeProjectName(name)
 	if err := ValidateProjectName(name); err != nil {
 		return "", err
 	}
@@ -123,34 +142,84 @@ const EnvFileName = ".env"
 
 // EnvSave 持久化 .env；env 非空时写入，否则确保空 .env 文件存在（防止 env_file: .env 因缺文件报错）。
 // bak 非空时同时写 .env.bak。
-func EnvSave(installDir, env, bak string) {
+func EnvSave(installDir, env, bak string) error {
 	if installDir == "" {
-		return
+		return nil
 	}
-	_ = os.MkdirAll(installDir, 0755)
+	if err := os.MkdirAll(installDir, 0755); err != nil {
+		return fmt.Errorf("创建环境文件目录失败: %w", err)
+	}
 	envPath := filepath.Join(installDir, EnvFileName)
 	if env != "" {
-		_ = os.WriteFile(envPath, []byte(env), 0644)
+		if err := os.WriteFile(envPath, []byte(env), 0644); err != nil {
+			return fmt.Errorf("写入 .env 失败: %w", err)
+		}
 	} else {
 		if _, err := os.Stat(envPath); os.IsNotExist(err) {
-			_ = os.WriteFile(envPath, []byte(""), 0644)
+			if err := os.WriteFile(envPath, []byte(""), 0644); err != nil {
+				return fmt.Errorf("创建 .env 失败: %w", err)
+			}
+		} else if err != nil {
+			return fmt.Errorf("检查 .env 失败: %w", err)
 		}
 	}
 	if bak != "" {
-		_ = os.WriteFile(filepath.Join(installDir, EnvFileName+".bak"), []byte(bak), 0644)
+		if err := os.WriteFile(filepath.Join(installDir, EnvFileName+".bak"), []byte(bak), 0644); err != nil {
+			return fmt.Errorf("写入 .env.bak 失败: %w", err)
+		}
 	}
+	return nil
+}
+
+// EnvState 记录 .env 的原始内容及是否存在，用于失败回滚。
+type EnvState struct {
+	Content string
+	Exists  bool
+}
+
+// EnvStateRead 读取可精确恢复的 .env 状态。
+func EnvStateRead(installDir string) (EnvState, error) {
+	if installDir == "" {
+		return EnvState{}, nil
+	}
+	data, err := os.ReadFile(filepath.Join(installDir, EnvFileName))
+	if os.IsNotExist(err) {
+		return EnvState{}, nil
+	}
+	if err != nil {
+		return EnvState{}, fmt.Errorf("读取 .env 失败: %w", err)
+	}
+	return EnvState{Content: string(data), Exists: true}, nil
+}
+
+// EnvStateRestore 精确恢复 .env，包括空文件和原本不存在两种状态。
+func EnvStateRestore(installDir string, state EnvState) error {
+	if installDir == "" {
+		return nil
+	}
+	path := filepath.Join(installDir, EnvFileName)
+	if !state.Exists {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("恢复 .env 缺失状态失败: %w", err)
+		}
+		return nil
+	}
+	if err := os.MkdirAll(installDir, 0755); err != nil {
+		return fmt.Errorf("创建环境文件目录失败: %w", err)
+	}
+	if err := os.WriteFile(path, []byte(state.Content), 0644); err != nil {
+		return fmt.Errorf("恢复 .env 失败: %w", err)
+	}
+	return nil
 }
 
 // EnvContentRead 读取项目 .env 内容；文件不存在时返回空串。
 func EnvContentRead(installDir string) string {
-	if installDir == "" {
-		return ""
-	}
-	data, err := os.ReadFile(filepath.Join(installDir, EnvFileName))
+	state, err := EnvStateRead(installDir)
 	if err != nil {
 		return ""
 	}
-	return string(data)
+	return state.Content
 }
 
 // InitFilesHandle 处理附加运行文件（支持本地上传或 URL 下载），解压到 installDir。

--- a/pkgs/compose/runtime.go
+++ b/pkgs/compose/runtime.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/docker/api/types/container"
+	"github.com/goccy/go-yaml"
 	"github.com/rehiy/libgo/archive"
 	"github.com/rehiy/libgo/request"
 )
@@ -57,6 +58,26 @@ func ContentProjectName(ctx context.Context, content string) (string, error) {
 		return "", err
 	}
 	return ProjectNameFromProject(project, content)
+}
+
+// ProjectNameFromContentShallow 用 YAML 浅解析提取顶层 name 字段，缺失时使用内容短哈希。
+// 与 LoadProjectFromContent 不同，它不做完整的 compose 解析（不解析 env_file / 插值），
+// 适用于「仅需拿到项目名」的探测场景，避免在 .env 尚未写盘时报 env file not found。
+func ProjectNameFromContentShallow(content string) (string, error) {
+	var doc struct {
+		Name string `yaml:"name"`
+	}
+	if err := yaml.Unmarshal([]byte(content), &doc); err != nil {
+		return "", fmt.Errorf("解析 compose 失败: %w", err)
+	}
+	name := doc.Name
+	if name == "" || name == "." {
+		name = ShortHash(content)
+	}
+	if err := ValidateProjectName(name); err != nil {
+		return "", err
+	}
+	return name, nil
 }
 
 // ==================== Project loading and persistence ====================

--- a/pkgs/compose/runtime.go
+++ b/pkgs/compose/runtime.go
@@ -9,11 +9,8 @@ import (
 	"path/filepath"
 	"regexp"
 
-	"github.com/compose-spec/compose-go/v2/interpolation"
-	"github.com/compose-spec/compose-go/v2/loader"
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/docker/api/types/container"
-	"github.com/goccy/go-yaml"
 	"github.com/rehiy/libgo/archive"
 	"github.com/rehiy/libgo/request"
 )
@@ -63,40 +60,6 @@ func ContentProjectName(ctx context.Context, content string) (string, error) {
 		return "", err
 	}
 	return ProjectNameFromProject(project, content)
-}
-
-// ProjectNameFromContentShallow 用 YAML 浅解析提取顶层 name 字段，缺失时使用内容短哈希。
-// 它仅对 name 做插值和 compose-go 同款规范化，不解析 services/env_file。
-func ProjectNameFromContentShallow(ctx context.Context, content, envContent string) (string, error) {
-	var doc struct {
-		Name string `yaml:"name"`
-	}
-	if err := yaml.Unmarshal([]byte(content), &doc); err != nil {
-		return "", fmt.Errorf("解析 compose 失败: %w", err)
-	}
-	if doc.Name == "" || doc.Name == "." {
-		return projectNameOrHash(doc.Name, content)
-	}
-
-	env, err := projectEnvironmentWithEnvFile(ctx, nil, envContent, "")
-	if err != nil {
-		return "", err
-	}
-	result, err := interpolation.Interpolate(map[string]any{"name": doc.Name}, interpolation.Options{
-		LookupValue: func(key string) (string, bool) {
-			value, ok := env[key]
-			return value, ok
-		},
-	})
-	if err != nil {
-		return "", fmt.Errorf("解析 compose 项目名失败: %w", err)
-	}
-	name, _ := result["name"].(string)
-	name = loader.NormalizeProjectName(name)
-	if err := ValidateProjectName(name); err != nil {
-		return "", err
-	}
-	return name, nil
 }
 
 // ==================== Project loading and persistence ====================

--- a/pkgs/compose/runtime.go
+++ b/pkgs/compose/runtime.go
@@ -186,13 +186,13 @@ func EnvStateRestore(installDir string, state EnvState) error {
 	return nil
 }
 
-// EnvContentRead 读取项目 .env 内容；文件不存在时返回空串。
-func EnvContentRead(installDir string) string {
+// EnvContentRead 读取项目 .env 内容；文件不存在时返回空串。读取失败（权限、IO 等）向上返回错误
+func EnvContentRead(installDir string) (string, error) {
 	state, err := EnvStateRead(installDir)
 	if err != nil {
-		return ""
+		return "", err
 	}
-	return state.Content
+	return state.Content, nil
 }
 
 // InitFilesHandle 处理附加运行文件（支持本地上传或 URL 下载），解压到 installDir。

--- a/pkgs/compose/runtime.go
+++ b/pkgs/compose/runtime.go
@@ -97,6 +97,41 @@ func ContentSave(installDir, content, bak string) {
 	}
 }
 
+// EnvFileName 项目 .env 文件名。
+const EnvFileName = ".env"
+
+// EnvSave 持久化 .env；env 非空时写入，否则确保空 .env 文件存在（防止 env_file: .env 因缺文件报错）。
+// bak 非空时同时写 .env.bak。
+func EnvSave(installDir, env, bak string) {
+	if installDir == "" {
+		return
+	}
+	_ = os.MkdirAll(installDir, 0755)
+	envPath := filepath.Join(installDir, EnvFileName)
+	if env != "" {
+		_ = os.WriteFile(envPath, []byte(env), 0644)
+	} else {
+		if _, err := os.Stat(envPath); os.IsNotExist(err) {
+			_ = os.WriteFile(envPath, []byte(""), 0644)
+		}
+	}
+	if bak != "" {
+		_ = os.WriteFile(filepath.Join(installDir, EnvFileName+".bak"), []byte(bak), 0644)
+	}
+}
+
+// EnvContentRead 读取项目 .env 内容；文件不存在时返回空串。
+func EnvContentRead(installDir string) string {
+	if installDir == "" {
+		return ""
+	}
+	data, err := os.ReadFile(filepath.Join(installDir, EnvFileName))
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
 // InitFilesHandle 处理附加运行文件（支持本地上传或 URL 下载），解压到 installDir。
 func InitFilesHandle(installDir string, payload InitPayload) error {
 	if payload.File == nil && payload.URL == "" {

--- a/webview/src/service/api.ts
+++ b/webview/src/service/api.ts
@@ -751,6 +751,9 @@ class ApiService {
     private composeDeployForm(data: ComposeDeploy) {
         const form = new FormData()
         form.append('content', data.content)
+        if (data.envContent) {
+            form.append('envContent', data.envContent)
+        }
         // 文件优先，二者互斥
         if (data.initFile) {
             form.append('initFile', data.initFile)

--- a/webview/src/service/types/compose.ts
+++ b/webview/src/service/types/compose.ts
@@ -6,18 +6,15 @@ export type ComposeDeployTarget = 'docker' | 'swarm'
 // 项目名（projectName）从 compose 文件中的 name: 字段自动获取，无需前端填写
 export interface ComposeDeploy {
     content: string         // 完整 compose yaml 文本
-    envContent?: string     // 可选：.env 内容（KEY=VALUE），后端合并进变量插值环境并写盘
+    envContent?: string     // 省略表示保留附加文件解压出的 .env；提交内容则以其为准
     initURL?: string        // 可选：附加运行文件 zip 下载地址
     initFile?: File         // 可选：附加运行文件（与 initURL 互斥，文件优先）
 }
 
-// Compose Redeploy 请求
-// - content 非空，serviceName 为空：全量重建
-// - serviceName + image 非空：按服务更新镜像重建
-// - envContent 单独非空（content 为空）：仅更新 .env 后重建
+// Compose Redeploy 请求（部分更新：提交哪个字段就改哪个字段，未提交的保持不变；content 提交空串会被后端拒绝）
 export interface ComposeRedeploy {
     content?: string
-    envContent?: string
+    envContent?: string     // 省略表示保留现有 .env；空串表示清空；提交内容则覆盖
     serviceName?: string
     image?: string
 }

--- a/webview/src/service/types/compose.ts
+++ b/webview/src/service/types/compose.ts
@@ -5,7 +5,8 @@ export type ComposeDeployTarget = 'docker' | 'swarm'
 // 统一的 compose 部署请求
 // 项目名（projectName）从 compose 文件中的 name: 字段自动获取，无需前端填写
 export interface ComposeDeploy {
-    content: string         // 完整 compose yaml 文本（前端已完成 ${VAR} 插值）
+    content: string         // 完整 compose yaml 文本
+    envContent?: string     // 可选：.env 内容（KEY=VALUE），后端合并进变量插值环境并写盘
     initURL?: string        // 可选：附加运行文件 zip 下载地址
     initFile?: File         // 可选：附加运行文件（与 initURL 互斥，文件优先）
 }
@@ -13,8 +14,10 @@ export interface ComposeDeploy {
 // Compose Redeploy 请求
 // - content 非空，serviceName 为空：全量重建
 // - serviceName + image 非空：按服务更新镜像重建
+// - envContent 单独非空（content 为空）：仅更新 .env 后重建
 export interface ComposeRedeploy {
     content?: string
+    envContent?: string
     serviceName?: string
     image?: string
 }

--- a/webview/src/service/types/docker.ts
+++ b/webview/src/service/types/docker.ts
@@ -89,7 +89,7 @@ export interface DockerContainerDetail extends DockerContainerCreate {
 // 容器 Compose
 export interface DockerContainerCompose {
     content: string
-    envContent?: string
+    envContent?: string     // 项目 .env 文本；磁盘无文件时不返回
     projectName?: string
     fileModTime?: number
     source?: 'file' | 'runtime'

--- a/webview/src/service/types/docker.ts
+++ b/webview/src/service/types/docker.ts
@@ -89,6 +89,7 @@ export interface DockerContainerDetail extends DockerContainerCreate {
 // 容器 Compose
 export interface DockerContainerCompose {
     content: string
+    envContent?: string
     projectName?: string
     fileModTime?: number
     source?: 'file' | 'runtime'

--- a/webview/src/service/types/swarm.ts
+++ b/webview/src/service/types/swarm.ts
@@ -97,7 +97,7 @@ export type SwarmCreateService = SwarmServiceSpec
 // Swarm 服务 Compose
 export interface SwarmServiceCompose {
     content: string
-    envContent?: string
+    envContent?: string     // 项目 .env 文本；磁盘无文件时不返回
     projectName?: string
     fileModTime?: number
     source?: 'file' | 'runtime'

--- a/webview/src/service/types/swarm.ts
+++ b/webview/src/service/types/swarm.ts
@@ -97,6 +97,7 @@ export type SwarmCreateService = SwarmServiceSpec
 // Swarm 服务 Compose
 export interface SwarmServiceCompose {
     content: string
+    envContent?: string
     projectName?: string
     fileModTime?: number
     source?: 'file' | 'runtime'

--- a/webview/src/views/compose/deploy.vue
+++ b/webview/src/views/compose/deploy.vue
@@ -211,7 +211,7 @@ export default toNative(ComposeDeploy)
       </div>
 
       <!-- 表单 -->
-      <div class="card-body max-w-3xl space-y-4">
+      <div class="card-body mx-auto w-full max-w-[1600px] space-y-4">
         <!-- 部署目标 -->
         <div class="tab-group inline-flex">
           <button type="button" :class="['tab-btn', target === 'docker' ? 'tab-btn-active text-amber-600' : 'tab-btn-inactive']" @click="selectTarget('docker')">
@@ -230,20 +230,15 @@ export default toNative(ComposeDeploy)
           </button>
         </div>
 
-        <!-- Compose 内容 -->
-        <ComposeEditor v-model="content" :disabled="loading" :warning="dynamicWarning" />
-
-        <!-- 环境变量 .env -->
-        <details class="group" :open="!!envContent">
-          <summary class="form-label cursor-pointer select-none">
-            <i class="fas fa-chevron-right mr-1 text-slate-400 transition-transform group-open:rotate-90"></i>
-            环境变量 .env
-            <span class="text-xs font-normal text-slate-400">（选填，部署时合并进变量插值环境）</span>
-          </summary>
-          <div class="mt-2">
+        <!-- Compose 内容 + 环境变量 .env：左右布局（compose 左，.env 右） -->
+        <div class="grid gap-4 lg:grid-cols-2">
+          <div class="min-w-0">
+            <ComposeEditor v-model="content" :disabled="loading" :warning="dynamicWarning" />
+          </div>
+          <div class="min-w-0">
             <EnvEditor v-model="envContent" :disabled="loading" />
           </div>
-        </details>
+        </div>
 
         <!-- 附加文件 -->
         <div>

--- a/webview/src/views/compose/deploy.vue
+++ b/webview/src/views/compose/deploy.vue
@@ -9,9 +9,10 @@ import { MARKETPLACE_PICK_STORAGE_KEY } from '@/service/types'
 import type { ComposeDeployTarget, ComposeMarketplacePick } from '@/service/types'
 
 import ComposeEditor from './widget/compose-editor.vue'
+import EnvEditor from './widget/env-editor.vue'
 
 @Component({
-    components: { ComposeEditor }
+    components: { ComposeEditor, EnvEditor }
 })
 class ComposeDeploy extends Vue {
     portal = usePortal()
@@ -24,6 +25,7 @@ class ComposeDeploy extends Vue {
     initURL = ''
     initFile: File | null = null
     content = ''
+    envContent = ''
 
     // 预填态（来自应用市场一键选择）：仅用于头部提示徽章，不锁定输入
     fromMarketplace = false
@@ -47,7 +49,7 @@ class ComposeDeploy extends Vue {
         if (this.fromMarketplace) {
             return '已从应用市场预填模板，可在此基础上直接部署或调整后再部署'
         }
-        return '项目名来自 compose 文件的 name 字段；变量插值需在客户端完成，后端仅按原文落盘与加载'
+        return '项目名来自 compose 文件的 name 字段；如 compose 中引用了 ${VAR}，请在下方 .env 中填写对应变量'
     }
 
     // ─── 方法 ───
@@ -118,11 +120,13 @@ class ComposeDeploy extends Vue {
             const res = this.target === 'swarm'
                 ? await api.composeSwarmDeploy({
                     content: this.content,
+                    envContent: this.envContent || undefined,
                     initURL: this.initURL.trim() || undefined,
                     initFile: this.initFile ?? undefined,
                 })
                 : await api.composeDockerDeploy({
                     content: this.content,
+                    envContent: this.envContent || undefined,
                     initURL: this.initURL.trim() || undefined,
                     initFile: this.initFile ?? undefined,
                 })
@@ -145,6 +149,7 @@ class ComposeDeploy extends Vue {
 
     resetForm() {
         this.content = ''
+        this.envContent = ''
         this.initURL = ''
         this.initFile = null
         this.target = 'docker'
@@ -227,6 +232,18 @@ export default toNative(ComposeDeploy)
 
         <!-- Compose 内容 -->
         <ComposeEditor v-model="content" :disabled="loading" :warning="dynamicWarning" />
+
+        <!-- 环境变量 .env -->
+        <details class="group" :open="!!envContent">
+          <summary class="form-label cursor-pointer select-none">
+            <i class="fas fa-chevron-right mr-1 text-slate-400 transition-transform group-open:rotate-90"></i>
+            环境变量 .env
+            <span class="text-xs font-normal text-slate-400">（选填，部署时合并进变量插值环境）</span>
+          </summary>
+          <div class="mt-2">
+            <EnvEditor v-model="envContent" :disabled="loading" />
+          </div>
+        </details>
 
         <!-- 附加文件 -->
         <div>

--- a/webview/src/views/compose/deploy.vue
+++ b/webview/src/views/compose/deploy.vue
@@ -49,7 +49,7 @@ class ComposeDeploy extends Vue {
         if (this.fromMarketplace) {
             return '已从应用市场预填模板，可在此基础上直接部署或调整后再部署'
         }
-        return '项目名来自 compose 文件的 name 字段；如 compose 中引用了 ${VAR}，请在下方 .env 中填写对应变量'
+        return '项目名来自 compose 文件的 name 字段；如 compose 中引用了环境变量，请在 .env 中填写对应变量'
     }
 
     // ─── 方法 ───

--- a/webview/src/views/compose/widget/env-editor.vue
+++ b/webview/src/views/compose/widget/env-editor.vue
@@ -1,0 +1,47 @@
+<script lang="ts">
+import { yaml } from '@codemirror/lang-yaml'
+import { Codemirror } from 'vue-codemirror'
+import { Component, Prop, Vue, toNative } from 'vue-facing-decorator'
+
+@Component({
+    components: { Codemirror },
+    emits: ['update:modelValue']
+})
+class EnvEditor extends Vue {
+    @Prop({ default: '' }) modelValue!: string
+    @Prop({ default: false }) disabled!: boolean
+    @Prop({ default: '25vh' }) height!: string
+    @Prop({ default: '' }) warning!: string
+
+    readonly extensions = [yaml()]
+
+    get content() {
+        return this.modelValue
+    }
+
+    set content(val: string) {
+        this.$emit('update:modelValue', val)
+    }
+}
+
+export default toNative(EnvEditor)
+</script>
+
+<template>
+  <div class="space-y-3">
+    <div>
+      <label class="form-label">
+        <i class="fas fa-file-code mr-1 text-slate-400"></i>.env
+        <span class="text-xs font-normal text-slate-400">（KEY=VALUE，部署时合并进变量插值环境）</span>
+      </label>
+      <div class="editor-container">
+        <Codemirror v-model="content" :style="{ height }" :extensions="extensions" :disabled="disabled" />
+      </div>
+    </div>
+    <div v-if="warning" class="bg-amber-50 border border-amber-200 rounded-lg p-3">
+      <p class="text-sm text-amber-700">
+        <i class="fas fa-exclamation-triangle mr-1"></i>{{ warning }}
+      </p>
+    </div>
+  </div>
+</template>

--- a/webview/src/views/docker/widget/container-edit-modal.vue
+++ b/webview/src/views/docker/widget/container-edit-modal.vue
@@ -93,7 +93,7 @@ class ContainerEditModal extends Vue {
         try {
             await api.composeDockerRedeploy(this.projectName, {
                 content: this.composeContent,
-                envContent: this.envContent || undefined
+                envContent: this.envContent
             })
             this.portal.showNotification('success', 'Compose 配置更新成功，已重建关联容器')
             this.isOpen = false

--- a/webview/src/views/docker/widget/container-edit-modal.vue
+++ b/webview/src/views/docker/widget/container-edit-modal.vue
@@ -10,10 +10,11 @@ import { COMPOSE_PROJECT_LABEL, COMPOSE_SERVICE_LABEL } from '@/service/types/do
 import BaseModal from '@/component/modal.vue'
 
 import ComposeEditor from '@/views/compose/widget/compose-editor.vue'
+import EnvEditor from '@/views/compose/widget/env-editor.vue'
 
 @Component({
     expose: ['show'],
-    components: { BaseModal, ComposeEditor },
+    components: { BaseModal, ComposeEditor, EnvEditor },
     emits: ['success']
 })
 class ContainerEditModal extends Vue {
@@ -26,6 +27,7 @@ class ContainerEditModal extends Vue {
     projectName = ''
     displayName = ''
     composeContent = ''
+    envContent = ''
     composeFileModTime = 0
     composeSource: 'file' | 'runtime' | '' = ''
 
@@ -53,6 +55,7 @@ class ContainerEditModal extends Vue {
             ? `${composeProject} / ${composeService || container.name}`
             : (container.name || container.id)
         this.composeContent = ''
+        this.envContent = ''
         this.composeFileModTime = 0
         this.composeSource = ''
         this.isOpen = true
@@ -66,6 +69,7 @@ class ContainerEditModal extends Vue {
             const res = await api.composeDockerInspect(this.projectName, force)
             const payload = res.payload
             this.composeContent = payload?.content || ''
+            this.envContent = payload?.envContent || ''
             this.projectName = payload?.projectName || this.projectName
             this.composeFileModTime = payload?.fileModTime || 0
             this.composeSource = payload?.source || ''
@@ -87,7 +91,10 @@ class ContainerEditModal extends Vue {
         if (!this.composeContent.trim()) return
         this.modalLoading = true
         try {
-            await api.composeDockerRedeploy(this.projectName, { content: this.composeContent })
+            await api.composeDockerRedeploy(this.projectName, {
+                content: this.composeContent,
+                envContent: this.envContent || undefined
+            })
             this.portal.showNotification('success', 'Compose 配置更新成功，已重建关联容器')
             this.isOpen = false
             this.$emit('success')
@@ -108,6 +115,9 @@ export default toNative(ContainerEditModal)
     </template>
 
     <ComposeEditor v-model="composeContent" :warning="composeWarning" />
+    <div class="mt-3">
+      <EnvEditor v-model="envContent" />
+    </div>
     <template #confirm-text>更新并重建</template>
   </BaseModal>
 </template>

--- a/webview/src/views/docker/widget/container-edit-modal.vue
+++ b/webview/src/views/docker/widget/container-edit-modal.vue
@@ -107,16 +107,20 @@ export default toNative(ContainerEditModal)
 </script>
 
 <template>
-  <BaseModal v-model="isOpen" :title="modalTitle" :loading="modalLoading" confirm-class="btn-emerald" show-footer @confirm="handleConfirm">
+  <BaseModal v-model="isOpen" :title="modalTitle" :loading="modalLoading" max-width-class="max-w-[80vw]" confirm-class="btn-emerald" show-footer @confirm="handleConfirm">
     <template #header-actions>
       <button type="button" class="btn-icon-sm" :disabled="modalLoading" title="跳过 compose.yml，按当前容器运行态重新反推 Compose" @click="handleForceRefresh()">
         <i :class="refreshing ? 'fas fa-spinner fa-spin' : 'fas fa-rotate'"></i>
       </button>
     </template>
 
-    <ComposeEditor v-model="composeContent" :warning="composeWarning" />
-    <div class="mt-3">
-      <EnvEditor v-model="envContent" />
+    <div class="grid gap-3 sm:grid-cols-2">
+      <div class="min-w-0">
+        <ComposeEditor v-model="composeContent" :warning="composeWarning" />
+      </div>
+      <div class="min-w-0">
+        <EnvEditor v-model="envContent" />
+      </div>
     </div>
     <template #confirm-text>更新并重建</template>
   </BaseModal>

--- a/webview/src/views/swarm/widget/service-edit-modal.vue
+++ b/webview/src/views/swarm/widget/service-edit-modal.vue
@@ -9,10 +9,11 @@ import type { SwarmServiceInfo } from '@/service/types'
 import BaseModal from '@/component/modal.vue'
 
 import ComposeEditor from '@/views/compose/widget/compose-editor.vue'
+import EnvEditor from '@/views/compose/widget/env-editor.vue'
 
 @Component({
     expose: ['show'],
-    components: { BaseModal, ComposeEditor },
+    components: { BaseModal, ComposeEditor, EnvEditor },
     emits: ['success']
 })
 class ServiceEditModal extends Vue {
@@ -23,6 +24,7 @@ class ServiceEditModal extends Vue {
     modalLoading = false
     refreshing = false
     composeContent = ''
+    envContent = ''
     serviceName = ''
     composeFileModTime = 0
     composeSource: 'file' | 'runtime' | '' = ''
@@ -42,6 +44,7 @@ class ServiceEditModal extends Vue {
     async show(svc: SwarmServiceInfo) {
         this.serviceName = svc.name
         this.composeContent = ''
+        this.envContent = ''
         this.composeFileModTime = 0
         this.composeSource = ''
         this.isOpen = true
@@ -55,6 +58,7 @@ class ServiceEditModal extends Vue {
             const res = await api.composeSwarmInspect(this.serviceName, force)
             const payload = res.payload
             this.composeContent = payload?.content || ''
+            this.envContent = payload?.envContent || ''
             this.composeFileModTime = payload?.fileModTime || 0
             this.composeSource = payload?.source || ''
             if (force) this.portal.showNotification('success', '已从运行态重新反推 Compose 配置')
@@ -75,7 +79,10 @@ class ServiceEditModal extends Vue {
         if (!this.composeContent.trim()) return
         this.modalLoading = true
         try {
-            await api.composeSwarmRedeploy(this.serviceName, { content: this.composeContent })
+            await api.composeSwarmRedeploy(this.serviceName, {
+                content: this.composeContent,
+                envContent: this.envContent || undefined
+            })
             this.portal.showNotification('success', 'Swarm 服务配置更新成功，已重建服务')
             this.isOpen = false
             this.$emit('success')
@@ -96,6 +103,9 @@ export default toNative(ServiceEditModal)
     </template>
 
     <ComposeEditor v-model="composeContent" :warning="composeWarning" />
+    <div class="mt-3">
+      <EnvEditor v-model="envContent" />
+    </div>
     <template #confirm-text>更新并重建</template>
   </BaseModal>
 </template>

--- a/webview/src/views/swarm/widget/service-edit-modal.vue
+++ b/webview/src/views/swarm/widget/service-edit-modal.vue
@@ -81,7 +81,7 @@ class ServiceEditModal extends Vue {
         try {
             await api.composeSwarmRedeploy(this.serviceName, {
                 content: this.composeContent,
-                envContent: this.envContent || undefined
+                envContent: this.envContent
             })
             this.portal.showNotification('success', 'Swarm 服务配置更新成功，已重建服务')
             this.isOpen = false

--- a/webview/src/views/swarm/widget/service-edit-modal.vue
+++ b/webview/src/views/swarm/widget/service-edit-modal.vue
@@ -95,16 +95,20 @@ export default toNative(ServiceEditModal)
 </script>
 
 <template>
-  <BaseModal v-model="isOpen" :title="`编辑服务：${serviceName}`" :loading="modalLoading" confirm-class="btn-emerald" show-footer @confirm="handleConfirm">
+  <BaseModal v-model="isOpen" :title="`编辑服务：${serviceName}`" :loading="modalLoading" max-width-class="max-w-[80vw]" confirm-class="btn-emerald" show-footer @confirm="handleConfirm">
     <template #header-actions>
       <button type="button" class="btn-icon-sm" :disabled="modalLoading" title="跳过 compose.yml，按当前服务运行态重新反推 Compose" @click="handleForceRefresh()">
         <i :class="refreshing ? 'fas fa-spinner fa-spin' : 'fas fa-rotate'"></i>
       </button>
     </template>
 
-    <ComposeEditor v-model="composeContent" :warning="composeWarning" />
-    <div class="mt-3">
-      <EnvEditor v-model="envContent" />
+    <div class="grid gap-3 sm:grid-cols-2">
+      <div class="min-w-0">
+        <ComposeEditor v-model="composeContent" :warning="composeWarning" />
+      </div>
+      <div class="min-w-0">
+        <EnvEditor v-model="envContent" />
+      </div>
     </div>
     <template #confirm-text>更新并重建</template>
   </BaseModal>


### PR DESCRIPTION
## 背景
Compose 部署时 .env 无法在线编辑，compose 中 `env_file` 引用 `.env` 会导致部署直接失败；

## 新增能力
- 部署/重建请求新增 envContent 字段，.env 作为项目文件落盘持久化；支持仅更新 .env 不动 compose（ctrl_compose.go、service.go）
- 加载 compose 时自动读取 WorkingDir/.env 并合并进插值环境，避免 env_file: .env 因缺文件报错
- 前端新增 EnvEditor 组件，部署页（左右布局、内容区限宽 1600px）与 Docker/Swarm 编辑弹窗（80vw 分栏）接入
- - EnvSave 返回错误、新增 EnvStateRead/EnvStateRestore 精确恢复 .env（含"原本不存在"状态），部署/重建失败时回滚 .env
  
## API 变更
`PUT /compose/docker/:name`、`PUT /compose/swarm/:name` 请求体语义调整：
 - `content` 由 `string` 改为 `*string`
  - 省略（nil）→ 沿用现有 compose.yml
  - 显式提交空字符串 → **400 拒绝**（旧版在 serviceName 场景下可被忽略）
- `serviceName` 与 `content` / `envContent` 互斥
  - 同时提交 `serviceName + content` → **400**（旧版静默丢弃 content）
  - 同时提交 `serviceName + envContent` → **400**
- 校验规则由「content 必填」改为「content 与 envContent 至少提交一项」  

新增字段（向后兼容）
  - 部署请求 `POST /compose/docker`、`POST /compose/swarm` 新增可选 `envContent`
  - 重建请求新增可选 `envContent`
    - nil → 保留现有 .env
    - 空串 → 清空 .env
    - 非空 → 覆盖 .env
  - 详情/列表响应新增 `envContent` 字段

_除「`serviceName` 与 `content`/`envContent` 同时提交」的场景外，其余情况，旧客户端无感_
 
<img width="2269" height="1244" alt="Clipboard_Screenshot_1785846120" src="https://github.com/user-attachments/assets/834cabc9-c92b-4c9e-a6c6-3255ca21b498" />
