### PR TITLE
fix(swarm): 重建服务前等待旧服务确实移除，避免 AlreadyExists

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.25.0
 
 require (
 	github.com/compose-spec/compose-go/v2 v2.12.1
-	github.com/containerd/errdefs v1.0.0
 	github.com/coreos/go-oidc/v3 v3.19.0
 	github.com/creack/pty v1.1.24
 	github.com/docker/docker v28.5.2+incompatible
@@ -32,6 +31,7 @@ require (
 	github.com/cheggaaa/pb/v3 v3.1.7 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/cloudwego/base64x v0.1.7 // indirect
+	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/distribution/reference v0.6.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/compose-spec/compose-go/v2 v2.12.1
+	github.com/containerd/errdefs v1.0.0
 	github.com/coreos/go-oidc/v3 v3.19.0
 	github.com/creack/pty v1.1.24
 	github.com/docker/docker v28.5.2+incompatible
@@ -31,7 +32,6 @@ require (
 	github.com/cheggaaa/pb/v3 v3.1.7 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/cloudwego/base64x v0.1.7 // indirect
-	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/distribution/reference v0.6.0 // indirect

--- a/internal/service/compose/swarm.go
+++ b/internal/service/compose/swarm.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/rehiy/libgo/logman"
@@ -12,6 +13,9 @@ import (
 	"isrvd/pkgs/compose"
 	"isrvd/pkgs/docker"
 )
+
+// swarmServiceRemoveTimeout 等待旧服务从集群状态中彻底消失的超时时间
+const swarmServiceRemoveTimeout = 10 * time.Second
 
 // SwarmDeploy 部署新的 Swarm Compose 项目。
 func (s *Service) SwarmDeploy(ctx context.Context, req DeployRequest) (*DeployResult, error) {
@@ -220,7 +224,11 @@ func (s *Service) SwarmRedeploy(ctx context.Context, name string, req RedeployRe
 		return nil, err
 	}
 
-	s.swarmServicesRemove(ctx, name, oldContent)
+	// 旧服务尚未确认移除干净前不能进入创建阶段，否则必然撞上 AlreadyExists；
+	// 此时还未写盘任何新内容，直接返回即可，无需走回滚
+	if err := s.swarmServicesRemove(ctx, name, oldContent); err != nil {
+		return nil, fmt.Errorf("移除旧服务失败: %w", err)
+	}
 
 	rollback := func() string {
 		// 先恢复旧 .env 再回滚服务；.env 失败不阻断服务回滚
@@ -271,7 +279,7 @@ func (s *Service) swarmServicesCreate(ctx context.Context, project *types.Projec
 
 	rollback := func() {
 		for _, id := range createdIDs {
-			if err := s.swarm.ServiceAction(ctx, id, "remove", nil); err != nil {
+			if err := s.swarm.ServiceRemoveAndWait(ctx, id, swarmServiceRemoveTimeout); err != nil {
 				logman.Warn("Rollback remove service failed", "id", id, "error", err)
 			}
 		}
@@ -304,18 +312,22 @@ func (s *Service) swarmServiceCreate(ctx context.Context, project *types.Project
 	return id, spec.Name, nil
 }
 
-// swarmServicesRemove 移除 project 中的所有 Swarm 服务
-func (s *Service) swarmServicesRemove(ctx context.Context, name, content string) {
+// swarmServicesRemove 移除 project 中的所有 Swarm 服务，并等待其从集群状态中彻底消失，
+// 避免紧随其后的同名 create 撞上 Docker daemon 异步清理导致的 AlreadyExists。
+func (s *Service) swarmServicesRemove(ctx context.Context, name, content string) error {
 	if content == "" {
-		return
+		return nil
 	}
 	project, err := compose.LoadProjectFromContent(ctx, content, name)
 	if err != nil {
-		return
+		return err
 	}
 	for _, svc := range project.Services {
-		_ = s.swarm.ServiceAction(ctx, svc.Name, "remove", nil)
+		if err := s.swarm.ServiceRemoveAndWait(ctx, svc.Name, swarmServiceRemoveTimeout); err != nil {
+			return fmt.Errorf("移除服务 %s 失败: %w", svc.Name, err)
+		}
 	}
+	return nil
 }
 
 // swarmRollback 用指定配置内容重建 Swarm 服务（回滚用）

--- a/pkgs/swarm/service.go
+++ b/pkgs/swarm/service.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"time"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	dockerSwarm "github.com/docker/docker/api/types/swarm"
@@ -63,6 +64,32 @@ func (s *SwarmService) ServiceAction(ctx context.Context, id, action string, rep
 	}
 
 	return fmt.Errorf("不支持的操作: %s", action)
+}
+
+// ServiceRemoveAndWait 移除服务，并轮询等待其从集群状态中彻底消失后再返回。
+// service rm 在 daemon 内部是异步清理的，若不等待确认就立即以同名重建，
+// 存在竞态窗口会导致 create 返回 AlreadyExists。
+func (s *SwarmService) ServiceRemoveAndWait(ctx context.Context, id string, timeout time.Duration) error {
+	if err := s.client.ServiceRemove(ctx, id); err != nil && !cerrdefs.IsNotFound(err) {
+		logman.Error("ServiceRemove failed", "id", id, "error", err)
+		return err
+	}
+
+	deadline := time.Now().Add(timeout)
+	for {
+		_, _, err := s.client.ServiceInspectWithRaw(ctx, id, dockerSwarm.ServiceInspectOptions{})
+		if cerrdefs.IsNotFound(err) {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("等待服务 %s 移除超时", id)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(200 * time.Millisecond):
+		}
+	}
 }
 
 // ServiceCreate 创建服务，直接接收 Docker SDK 原始 ServiceSpec。

--- a/pkgs/swarm/service.go
+++ b/pkgs/swarm/service.go
@@ -7,10 +7,10 @@ import (
 	"io"
 	"time"
 
-	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	dockerSwarm "github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/rehiy/libgo/httpd"
 	"github.com/rehiy/libgo/logman"
@@ -70,7 +70,7 @@ func (s *SwarmService) ServiceAction(ctx context.Context, id, action string, rep
 // service rm 在 daemon 内部是异步清理的，若不等待确认就立即以同名重建，
 // 存在竞态窗口会导致 create 返回 AlreadyExists。
 func (s *SwarmService) ServiceRemoveAndWait(ctx context.Context, id string, timeout time.Duration) error {
-	if err := s.client.ServiceRemove(ctx, id); err != nil && !cerrdefs.IsNotFound(err) {
+	if err := s.client.ServiceRemove(ctx, id); err != nil && !client.IsErrNotFound(err) {
 		logman.Error("ServiceRemove failed", "id", id, "error", err)
 		return err
 	}
@@ -78,7 +78,7 @@ func (s *SwarmService) ServiceRemoveAndWait(ctx context.Context, id string, time
 	deadline := time.Now().Add(timeout)
 	for {
 		_, _, err := s.client.ServiceInspectWithRaw(ctx, id, dockerSwarm.ServiceInspectOptions{})
-		if cerrdefs.IsNotFound(err) {
+		if client.IsErrNotFound(err) {
 			return nil
 		}
 		if time.Now().After(deadline) {


### PR DESCRIPTION
## 起因

编辑 Swarm compose 服务配置后重新部署（`SwarmRedeploy`），偶发收到如下报错：

```
创建服务 litellm 失败: Error response from daemon: rpc error: code = AlreadyExists
desc = name conflicts with an existing object: service litellm already exists；
回滚：.env 回滚成功，服务回滚失败（重建服务失败: 创建服务 litellm 失败: ...同样的 AlreadyExists...）
```

即：明明只是重新编辑了一下配置，却被告知服务"已存在"，回滚阶段还会再报一次同样的错误。

## 经过

`SwarmRedeploy` 采用“先删旧服务、再建新服务”的方式实现重新部署（而非 Swarm 原生的
`service update`）：

1. `swarmServicesRemove` 对旧 project 中的每个 service 调用 `docker service rm`，
   但**丢弃了返回的错误**（`_ = s.swarm.ServiceAction(...)`），删除请求发出后立即
   继续往下执行。
2. 紧接着不做任何等待，直接对新 project 调用 `docker service create` 建同名服务。
3. Docker Swarm 的 `service rm` 在 daemon 内部是**异步**清理的，命令返回成功不代表
   服务已经从 raft store 中彻底清除。若清理还没完成就以同名 `create`，会命中
   `AlreadyExists` 的竞态窗口。
4. 创建失败后触发的“回滚”（`swarmRollback`）本质上也是用旧配置重新 `create`，
   由于此时旧服务其实还没删干净，回滚重建**再次**撞上同样的冲突，产生了报错里
   那种嵌套的双重 `AlreadyExists`。

## 结果

新增 `SwarmService.ServiceRemoveAndWait`：发起 `ServiceRemove` 后轮询
`ServiceInspectWithRaw`，直到确认服务确实从集群状态消失（200ms 间隔，最长等待 10s）
再返回；不再吞掉删除阶段的错误。

- `swarmServicesRemove` 改为等待确认删除完成，并把失败原因正确传播出去；
  `SwarmRedeploy` 在旧服务未确认移除干净前不会进入创建阶段（此时还未写盘任何新
  内容，直接返回错误即可，无需回滚）。
- `swarmServicesCreate` 里创建失败后的清理逻辑，同样改为等待确认删除，避免同一
  竞态在“新建服务失败回滚”路径上复现。

已通过 `go build ./...` 与 `go vet ./...` 验证。

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [ ] 实际部署环境中复现原问题并验证修复（本地无法连接目标 Swarm 集群，未做端到端验证）