### PR TITLE
fix: 修复按服务更新镜像时无法读取项目 env_file

### DIFF
--- a/internal/service/compose/docker.go
+++ b/internal/service/compose/docker.go
@@ -208,7 +208,7 @@ func (s *Service) DockerRedeploy(ctx context.Context, name string, req RedeployR
 		return nil, err
 	}
 
-	s.dockerContainersRemove(ctx, name, oldContent, installDir)
+	s.dockerContainersRemove(ctx, name, oldContent, installDir, oldEnvState.Content)
 
 	rollback := func() string {
 		// 先恢复旧 .env 再回滚容器；.env 失败不阻断容器回滚
@@ -290,8 +290,9 @@ func (s *Service) dockerServiceCreate(ctx context.Context, project *types.Projec
 	return id, spec.Name, nil
 }
 
-// dockerContainersRemove 移除 project 中的所有 Docker 容器
-func (s *Service) dockerContainersRemove(ctx context.Context, name, content, installDir string) {
+// dockerContainersRemove 移除 project 中的所有 Docker 容器。
+// installDir 作为 compose 加载的工作目录（解析 env_file 等相对路径），envContent 用于叠加插值环境。
+func (s *Service) dockerContainersRemove(ctx context.Context, name, content, installDir, envContent string) {
 	removed := map[string]struct{}{}
 	removeByID := func(id string) {
 		if id == "" {
@@ -318,8 +319,13 @@ func (s *Service) dockerContainersRemove(ctx context.Context, name, content, ins
 
 	// 补充删除无标签的旧容器，inspect 确认归属后再删
 	if content != "" {
-		project, err := compose.LoadProjectFromContentInDir(ctx, content, installDir, name, nil)
-		if err == nil {
+		project, err := compose.LoadProjectFromContentInDir(ctx, content, installDir, name, &envContent)
+		if err != nil {
+			// 旧配置解析失败只影响无标签容器的补充清理，标签路径已覆盖大部分场景，
+			// 因此不阻断重建，但必须留痕，避免残留容器被静默忽略
+			logman.Warn("Parse old compose content for container cleanup failed",
+				"name", name, "install_dir", installDir, "error", err)
+		} else {
 			for _, svc := range project.Services {
 				for _, cname := range compose.DockerContainerNameCandidates(name, svc) {
 					info, err := s.docker.ContainerInspect(ctx, cname)

--- a/internal/service/compose/docker.go
+++ b/internal/service/compose/docker.go
@@ -318,7 +318,7 @@ func (s *Service) dockerContainersRemove(ctx context.Context, name, content, ins
 
 	// 补充删除无标签的旧容器，inspect 确认归属后再删
 	if content != "" {
-		project, err := compose.LoadProjectFromContent(ctx, content, installDir, name, nil)
+		project, err := compose.LoadProjectFromContentInDir(ctx, content, installDir, name, nil)
 		if err == nil {
 			for _, svc := range project.Services {
 				for _, cname := range compose.DockerContainerNameCandidates(name, svc) {

--- a/internal/service/compose/docker.go
+++ b/internal/service/compose/docker.go
@@ -208,7 +208,7 @@ func (s *Service) DockerRedeploy(ctx context.Context, name string, req RedeployR
 		return nil, err
 	}
 
-	s.dockerContainersRemove(ctx, name, oldContent)
+	s.dockerContainersRemove(ctx, name, oldContent, installDir)
 
 	rollback := func() string {
 		// 先恢复旧 .env 再回滚容器；.env 失败不阻断容器回滚
@@ -291,7 +291,7 @@ func (s *Service) dockerServiceCreate(ctx context.Context, project *types.Projec
 }
 
 // dockerContainersRemove 移除 project 中的所有 Docker 容器
-func (s *Service) dockerContainersRemove(ctx context.Context, name, content string) {
+func (s *Service) dockerContainersRemove(ctx context.Context, name, content, installDir string) {
 	removed := map[string]struct{}{}
 	removeByID := func(id string) {
 		if id == "" {
@@ -318,7 +318,7 @@ func (s *Service) dockerContainersRemove(ctx context.Context, name, content stri
 
 	// 补充删除无标签的旧容器，inspect 确认归属后再删
 	if content != "" {
-		project, err := compose.LoadProjectFromContent(ctx, content, name)
+		project, err := compose.LoadProjectFromContent(ctx, content, installDir, name, nil)
 		if err == nil {
 			for _, svc := range project.Services {
 				for _, cname := range compose.DockerContainerNameCandidates(name, svc) {

--- a/internal/service/compose/service.go
+++ b/internal/service/compose/service.go
@@ -128,7 +128,7 @@ func (s *Service) prepareRedeployContent(ctx context.Context, name, installDir, 
 		return "", contentErr
 	}
 
-	project, err := compose.LoadProjectFromContent(ctx, content, installDir, name, req.EnvContent)
+	project, err := compose.LoadProjectFromContentInDir(ctx, content, installDir, name, req.EnvContent)
 	if err != nil {
 		return "", err
 	}

--- a/internal/service/compose/service.go
+++ b/internal/service/compose/service.go
@@ -117,7 +117,7 @@ func (s *Service) prepareRedeployContent(ctx context.Context, name, installDir, 
 			return "", contentErr
 		}
 		var err error
-		content, err = compose.UpdateServiceImage(ctx, name, oldContent, req.ServiceName, req.Image)
+		content, err = compose.UpdateServiceImage(ctx, name, oldContent, req.ServiceName, req.Image, installDir)
 		if err != nil {
 			return "", err
 		}
@@ -128,7 +128,7 @@ func (s *Service) prepareRedeployContent(ctx context.Context, name, installDir, 
 		return "", contentErr
 	}
 
-	project, err := compose.LoadProjectFromContentInDir(ctx, content, installDir, name, req.EnvContent)
+	project, err := compose.LoadProjectFromContent(ctx, content, installDir, name, req.EnvContent)
 	if err != nil {
 		return "", err
 	}

--- a/internal/service/compose/swarm.go
+++ b/internal/service/compose/swarm.go
@@ -197,7 +197,7 @@ func (s *Service) SwarmRedeploy(ctx context.Context, name string, req RedeployRe
 
 	// 旧服务尚未确认移除干净前不能进入创建阶段，否则必然撞上 AlreadyExists；
 	// 此时还未写盘任何新内容，直接返回即可，无需走回滚
-	if err := s.swarmServicesRemove(ctx, name, oldContent, installDir); err != nil {
+	if err := s.swarmServicesRemove(ctx, name, oldContent, installDir, oldEnvState.Content); err != nil {
 		return nil, fmt.Errorf("移除旧服务失败: %w", err)
 	}
 
@@ -285,11 +285,12 @@ func (s *Service) swarmServiceCreate(ctx context.Context, project *types.Project
 
 // swarmServicesRemove 移除 project 中的所有 Swarm 服务，并等待其从集群状态中彻底消失，
 // 避免紧随其后的同名 create 撞上 Docker daemon 异步清理导致的 AlreadyExists。
-func (s *Service) swarmServicesRemove(ctx context.Context, name, content, installDir string) error {
+// installDir 作为 compose 加载的工作目录（解析 env_file 等相对路径），envContent 用于叠加插值环境。
+func (s *Service) swarmServicesRemove(ctx context.Context, name, content, installDir, envContent string) error {
 	if content == "" {
 		return nil
 	}
-	project, err := compose.LoadProjectFromContent(ctx, content, installDir, name, nil)
+	project, err := compose.LoadProjectFromContentInDir(ctx, content, installDir, name, &envContent)
 	if err != nil {
 		return err
 	}

--- a/internal/service/compose/swarm.go
+++ b/internal/service/compose/swarm.go
@@ -197,7 +197,7 @@ func (s *Service) SwarmRedeploy(ctx context.Context, name string, req RedeployRe
 
 	// 旧服务尚未确认移除干净前不能进入创建阶段，否则必然撞上 AlreadyExists；
 	// 此时还未写盘任何新内容，直接返回即可，无需走回滚
-	if err := s.swarmServicesRemove(ctx, name, oldContent); err != nil {
+	if err := s.swarmServicesRemove(ctx, name, oldContent, installDir); err != nil {
 		return nil, fmt.Errorf("移除旧服务失败: %w", err)
 	}
 
@@ -285,11 +285,11 @@ func (s *Service) swarmServiceCreate(ctx context.Context, project *types.Project
 
 // swarmServicesRemove 移除 project 中的所有 Swarm 服务，并等待其从集群状态中彻底消失，
 // 避免紧随其后的同名 create 撞上 Docker daemon 异步清理导致的 AlreadyExists。
-func (s *Service) swarmServicesRemove(ctx context.Context, name, content string) error {
+func (s *Service) swarmServicesRemove(ctx context.Context, name, content, installDir string) error {
 	if content == "" {
 		return nil
 	}
-	project, err := compose.LoadProjectFromContent(ctx, content, name)
+	project, err := compose.LoadProjectFromContent(ctx, content, installDir, name, nil)
 	if err != nil {
 		return err
 	}

--- a/pkgs/compose/project.go
+++ b/pkgs/compose/project.go
@@ -83,7 +83,7 @@ func LoadProject(ctx context.Context, opts LoadOptions) (*types.Project, error) 
 }
 
 // LoadProjectFromContentInDir 从 yaml 文本加载 compose 项目，并以 workingDir 作为项目目录解析相对路径。
-// workingDir 必须显式提供，缺失时直接报错，避免相对路径（env_file、volumes）被静默解析到进程当前目录。
+// workingDir 为空时回退到进程当前目录（与上游行为一致）。
 // envContent 为 nil 时仅读 workingDir/.env；非 nil 时在磁盘 .env 之上叠加。
 func LoadProjectFromContentInDir(ctx context.Context, content, workingDir, projectName string, envContent *string) (*types.Project, error) {
 	return loadProjectContent(ctx, content, workingDir, projectName, true, envContent, false)
@@ -97,7 +97,7 @@ func loadProjectContent(ctx context.Context, content, workingDir, projectName st
 		return nil, fmt.Errorf("compose 内容为空")
 	}
 	if workingDir == "" {
-		return nil, fmt.Errorf("缺少 compose 项目工作目录")
+		workingDir = "."
 	}
 
 	env, err := projectEnvironmentWithEnvFile(ctx, nil, envContent, workingDir)

--- a/pkgs/compose/project.go
+++ b/pkgs/compose/project.go
@@ -82,25 +82,21 @@ func LoadProject(ctx context.Context, opts LoadOptions) (*types.Project, error) 
 	}, projectName, true, true)
 }
 
-// LoadProjectFromContent 从 yaml 文本加载 compose 项目（不解析相对路径）。
-func LoadProjectFromContent(ctx context.Context, content string, projectName string) (*types.Project, error) {
-	return LoadProjectFromContentInDir(ctx, content, ".", projectName, nil)
-}
-
-// LoadProjectFromContentInDir 从 yaml 文本加载 compose 项目，并以 workingDir 解析相对路径。
+// LoadProjectFromContent 从 yaml 文本加载 compose 项目，并以 workingDir 作为项目目录解析相对路径。
 // envContent 为 nil 时仅读 workingDir/.env；非 nil 时在磁盘 .env 之上叠加。
-func LoadProjectFromContentInDir(ctx context.Context, content, workingDir, projectName string, envContent *string) (*types.Project, error) {
-	if workingDir == "" {
-		workingDir = "."
-	}
-	return loadProjectContent(ctx, content, workingDir, projectName, true, envContent)
+func LoadProjectFromContent(ctx context.Context, content, workingDir, projectName string, envContent *string) (*types.Project, error) {
+	return loadProjectContent(ctx, content, workingDir, projectName, true, envContent, false)
 }
 
 // loadProjectContent 从 yaml 文本加载 compose 项目，并合并指定的 .env 内容到插值环境。
 // envContent 为 nil 时仅读 workingDir/.env；非 nil 时在磁盘 .env 之上叠加。
-func loadProjectContent(ctx context.Context, content, workingDir, projectName string, resolvePaths bool, envContent *string) (*types.Project, error) {
+// skipServiceEnvironmentResolution 为 true 时不合并 services.environment/env_file。
+func loadProjectContent(ctx context.Context, content, workingDir, projectName string, resolvePaths bool, envContent *string, skipServiceEnvironmentResolution bool) (*types.Project, error) {
 	if content == "" {
 		return nil, fmt.Errorf("compose 内容为空")
+	}
+	if workingDir == "" {
+		return nil, fmt.Errorf("缺少 compose 项目工作目录")
 	}
 
 	env, err := projectEnvironmentWithEnvFile(ctx, nil, envContent, workingDir)
@@ -119,7 +115,13 @@ func loadProjectContent(ctx context.Context, content, workingDir, projectName st
 		Environment: env,
 	}
 
-	return loadProject(ctx, details, projectName, resolvePaths, projectName != "")
+	var configure func(*loader.Options)
+	if skipServiceEnvironmentResolution {
+		configure = func(o *loader.Options) {
+			o.SkipResolveEnvironment = true
+		}
+	}
+	return loadProjectWithOptions(ctx, details, projectName, resolvePaths, projectName != "", configure)
 }
 
 func loadProject(ctx context.Context, details types.ConfigDetails, projectName string, resolvePaths bool, setProjectName bool) (*types.Project, error) {

--- a/pkgs/compose/project.go
+++ b/pkgs/compose/project.go
@@ -82,9 +82,10 @@ func LoadProject(ctx context.Context, opts LoadOptions) (*types.Project, error) 
 	}, projectName, true, true)
 }
 
-// LoadProjectFromContent 从 yaml 文本加载 compose 项目，并以 workingDir 作为项目目录解析相对路径。
+// LoadProjectFromContentInDir 从 yaml 文本加载 compose 项目，并以 workingDir 作为项目目录解析相对路径。
+// workingDir 必须显式提供，缺失时直接报错，避免相对路径（env_file、volumes）被静默解析到进程当前目录。
 // envContent 为 nil 时仅读 workingDir/.env；非 nil 时在磁盘 .env 之上叠加。
-func LoadProjectFromContent(ctx context.Context, content, workingDir, projectName string, envContent *string) (*types.Project, error) {
+func LoadProjectFromContentInDir(ctx context.Context, content, workingDir, projectName string, envContent *string) (*types.Project, error) {
 	return loadProjectContent(ctx, content, workingDir, projectName, true, envContent, false)
 }
 

--- a/pkgs/compose/runtime.go
+++ b/pkgs/compose/runtime.go
@@ -59,7 +59,7 @@ func projectNameOrHash(name, content string) (string, error) {
 
 // ContentProjectName 从 compose 内容解析项目名，缺失时使用内容短哈希。
 func ContentProjectName(ctx context.Context, content string) (string, error) {
-	project, err := LoadProjectFromContent(ctx, content, "")
+	project, err := ProjectValidateWithoutEnvFiles(ctx, content, nil)
 	if err != nil {
 		return "", err
 	}
@@ -71,7 +71,7 @@ func ContentProjectName(ctx context.Context, content string) (string, error) {
 // ProjectLoad 写入 compose.yml 并以 installDir 为 WorkingDir 加载，确保相对路径正确展开。
 func ProjectLoad(ctx context.Context, name, content, installDir string) (*types.Project, error) {
 	if installDir == "" {
-		return LoadProjectFromContent(ctx, content, name)
+		return nil, fmt.Errorf("缺少 compose 项目工作目录")
 	}
 	if err := os.MkdirAll(installDir, 0755); err != nil {
 		return nil, fmt.Errorf("创建安装目录失败: %w", err)
@@ -85,9 +85,9 @@ func ProjectLoad(ctx context.Context, name, content, installDir string) (*types.
 // ProjectParse 解析 compose 内容（不写文件），相对路径基于 installDir 展开。
 func ProjectParse(ctx context.Context, name, content, installDir string) (*types.Project, error) {
 	if installDir == "" {
-		return LoadProjectFromContent(ctx, content, name)
+		return nil, fmt.Errorf("缺少 compose 项目工作目录")
 	}
-	return LoadProjectFromContentInDir(ctx, content, installDir, name, nil)
+	return LoadProjectFromContent(ctx, content, installDir, name, nil)
 }
 
 // ContentSave 持久化 compose.yml；bak 非空时同时写 compose.yml.bak。
@@ -233,11 +233,14 @@ func InitFilesHandle(installDir string, payload InitPayload) error {
 // ==================== Content mutation ====================
 
 // UpdateServiceImage 将 compose 内容中指定服务的镜像替换为 image，返回更新后的 YAML 文本。
-func UpdateServiceImage(ctx context.Context, name, content, serviceName, image string) (string, error) {
+func UpdateServiceImage(ctx context.Context, name, content, serviceName, image, installDir string) (string, error) {
 	if content == "" {
 		return "", fmt.Errorf("compose 内容不能为空")
 	}
-	project, err := LoadProjectFromContent(ctx, content, name)
+	if installDir == "" {
+		return "", fmt.Errorf("缺少 compose 项目工作目录")
+	}
+	project, err := loadProjectContent(ctx, content, installDir, name, false, nil, true)
 	if err != nil {
 		return "", err
 	}

--- a/pkgs/compose/runtime.go
+++ b/pkgs/compose/runtime.go
@@ -87,7 +87,7 @@ func ProjectParse(ctx context.Context, name, content, installDir string) (*types
 	if installDir == "" {
 		return nil, fmt.Errorf("缺少 compose 项目工作目录")
 	}
-	return LoadProjectFromContent(ctx, content, installDir, name, nil)
+	return LoadProjectFromContentInDir(ctx, content, installDir, name, nil)
 }
 
 // ContentSave 持久化 compose.yml；bak 非空时同时写 compose.yml.bak。


### PR DESCRIPTION
## Summary
修复 serviceName + image 更新镜像时，从 isrvd 工作目录查找 .env 导致 500 的问题。原因是错误的从 isrvd 进程目录查找 `env_file: ./.env`，而不是从 Compose 项目目录查找

现在统一使用 `containerRoot/<项目名>` 作为 Compose 工作目录，正确读取项目的 `.env`，并解析 `./data` 等相对路径
替换镜像字段后，后端会先验证新配置并拉取镜像，成功后才删除和重建旧容器
