### PR TITLE
feat(docker): 容器列表接口支持 Docker 原生 filters 过滤

### DIFF
--- a/docs/references/docker/containers.md
+++ b/docs/references/docker/containers.md
@@ -13,7 +13,19 @@ isrvd_get "/docker/info"
 ```bash
 isrvd_get "/docker/containers"
 isrvd_get "/docker/containers?all=true"
+# Docker 原生 filters 过滤（JSON 编码，需 URL 编码）
+isrvd_get "/docker/containers?filters={\"status\":[\"exited\"]}"
+isrvd_get "/docker/containers?filters={\"health\":[\"unhealthy\"]}"
+isrvd_get "/docker/containers?filters={\"name\":[\"webshot\"]}"
+isrvd_get "/docker/containers?filters={\"label\":[\"com.docker.compose.project\"]}"
 ```
+
+**查询参数：**
+
+| 参数 | 类型 | 说明 |
+|------|------|------|
+| all | boolean | 是否包含已停止的容器，默认 `false` |
+| filters | string | Docker 原生 filters 的 JSON 编码，如 `{"health":["unhealthy"]}`；支持 `status` / `health` / `name` / `label` / `network` / `volume` / `ancestor` 等 Docker 标准过滤键；格式错误返回 400 |
 
 返回 `ContainerInfo[]`：
 

--- a/internal/server/ctrl_docker.go
+++ b/internal/server/ctrl_docker.go
@@ -78,8 +78,14 @@ func (app *App) dockerInfo(c *gin.Context) {
 
 func (app *App) dockerContainerList(c *gin.Context) {
 	all := c.DefaultQuery("all", "false") == "true"
-	result, err := app.dockerSvc.ContainerList(c.Request.Context(), all)
+	result, err := app.dockerSvc.ContainerList(c.Request.Context(), all, c.Query("filters"))
 	if err != nil {
+		// Docker filters 解析失败属于调用方错误（SDK 以 InvalidParameter 标记），返回 400
+		var invalid interface{ InvalidParameter() }
+		if errors.As(err, &invalid) {
+			respondError(c, http.StatusBadRequest, "filters 参数格式错误: "+err.Error())
+			return
+		}
 		respondError(c, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/internal/service/docker/container.go
+++ b/internal/service/docker/container.go
@@ -45,9 +45,10 @@ type ContainerInfo struct {
 	Labels   map[string]string `json:"labels,omitempty"`   // 容器标签
 }
 
-// ContainerList 列出容器
-func (s *Service) ContainerList(ctx context.Context, all bool) ([]*ContainerInfo, error) {
-	list, err := s.docker.ContainerList(ctx, all)
+// ContainerList 列出容器。
+// filterJSON 为 Docker 原生 filters 的 JSON 编码（如 {"health":["unhealthy"]}），为空时不过滤。
+func (s *Service) ContainerList(ctx context.Context, all bool, filterJSON ...string) ([]*ContainerInfo, error) {
+	list, err := s.docker.ContainerList(ctx, all, filterJSON...)
 	if err != nil {
 		return nil, fmt.Errorf("获取容器列表失败: %w", err)
 	}

--- a/pkgs/docker/container.go
+++ b/pkgs/docker/container.go
@@ -11,8 +11,18 @@ import (
 )
 
 // ContainerList 获取容器列表，直接返回 Docker SDK 原始列表项。
-func (s *DockerService) ContainerList(ctx context.Context, all bool) ([]container.Summary, error) {
-	containers, err := s.client.ContainerList(ctx, container.ListOptions{All: all})
+// filterJSON 为 Docker 原生 filters 的 JSON 编码（如 {"health":["unhealthy"]}），为空时不过滤。
+func (s *DockerService) ContainerList(ctx context.Context, all bool, filterJSON ...string) ([]container.Summary, error) {
+	opts := container.ListOptions{All: all}
+	if len(filterJSON) > 0 && filterJSON[0] != "" {
+		args, err := filters.FromJSON(filterJSON[0])
+		if err != nil {
+			logman.Error("Parse container filters failed", "filters", filterJSON[0], "error", err)
+			return nil, err
+		}
+		opts.Filters = args
+	}
+	containers, err := s.client.ContainerList(ctx, opts)
 	if err != nil {
 		logman.Error("List containers failed", "error", err)
 		return nil, err


### PR DESCRIPTION
GET /api/docker/containers 新增 filters 查询参数，接受 Docker 原生 filters 的 JSON 编码（如 {"health":["unhealthy"]}），直接透传给 Docker daemon 过滤，与 Docker CLI 行为一致